### PR TITLE
feat: validate IDs

### DIFF
--- a/.changeset/odd-rats-look.md
+++ b/.changeset/odd-rats-look.md
@@ -1,0 +1,5 @@
+---
+"@graphprotocol/grc-20": minor
+---
+
+Update `QUOTES_THAT_SUPPORT_CLAIMS_PROPERTY` and `ACADEMIC_FIELD_TYPE` values to be valid IDs

--- a/.changeset/spicy-readers-shake.md
+++ b/.changeset/spicy-readers-shake.md
@@ -1,0 +1,5 @@
+---
+"@graphprotocol/grc-20": minor
+---
+
+IDs now use a branded type `Id` instead of `string` and validate every ID param

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ const { id: restaurantId, ops: createRestaurantOps } = Graph.createEntity({
     // relation property
     [propertyId]: {
       to: 'id of the entity',
+      relationId: 'id of the relation', // optional
+      position: positionString, // optional
+      properties: {
+        [propertyId]: {
+          type: 'TEXT', // TEXT | NUMBER | URL | TIME | POINT | CHECKBOX,
+          value: 'value of the property',
+        },
+      },
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -34,11 +34,10 @@
     "@changesets/cli": "^2.27.12",
     "@ethersproject/abi": "^5.6.4",
     "@ethersproject/providers": "^5.6.8",
-    "@types/uuid": "^9.0.8",
     "effect": "^3.12.11",
     "ethers": "^5.7.2",
     "position-strings": "^2.0.1",
-    "uuid": "^9.0.0",
+    "uuid": "^11.1.0",
     "viem": "^1.16.0",
     "vite": "^5.2.11",
     "vitest": "^1.6.0"
@@ -46,6 +45,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.31.0",
     "@bufbuild/protoc-gen-es": "^1.9.0",
+    "@types/uuid": "^10.0.0",
     "typescript": "^5.4.5"
   },
   "packageManager": "pnpm@10.4.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@ethersproject/providers':
         specifier: ^5.6.8
         version: 5.7.2
-      '@types/uuid':
-        specifier: ^9.0.8
-        version: 9.0.8
       effect:
         specifier: ^3.12.11
         version: 3.12.11
@@ -36,8 +33,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       viem:
         specifier: ^1.16.0
         version: 1.21.4(typescript@5.7.3)
@@ -54,6 +51,9 @@ importers:
       '@bufbuild/protoc-gen-es':
         specifier: ^1.9.0
         version: 1.10.0(@bufbuild/protobuf@1.10.0)
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       typescript:
         specifier: ^5.4.5
         version: 5.7.3
@@ -614,8 +614,8 @@ packages:
   '@types/seedrandom@2.4.34':
     resolution: {integrity: sha512-ytDiArvrn/3Xk6/vtylys5tlY6eo7Ane0hvcx++TKo6RxQXuVfW0AF/oeWqAj9dN29SyhtawuXstgmPlwNcv/A==}
 
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@typescript/vfs@1.6.1':
     resolution: {integrity: sha512-JwoxboBh7Oz1v38tPbkrZ62ZXNHAk9bJ7c9x0eI5zBfBnBYGhURdbnh7Z4smN/MV48Y5OCcZb58n972UtbazsA==}
@@ -1195,8 +1195,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
   viem@1.21.4:
@@ -1982,7 +1982,7 @@ snapshots:
 
   '@types/seedrandom@2.4.34': {}
 
-  '@types/uuid@9.0.8': {}
+  '@types/uuid@10.0.0': {}
 
   '@typescript/vfs@1.6.1(typescript@4.5.2)':
     dependencies:
@@ -2572,7 +2572,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  uuid@9.0.1: {}
+  uuid@11.1.0: {}
 
   viem@1.21.4(typescript@5.7.3):
     dependencies:

--- a/src/core/ids/content.ts
+++ b/src/core/ids/content.ts
@@ -1,203 +1,205 @@
-export const ARTICLE_TYPE = 'M5uDP7nCw3nvfQPUryn9gx';
-export const CITY_TYPE = 'D6Wy4bdtdoUrG3PDZceHr';
-export const CLAIM_TYPE = 'KeG9eTM8NUYFMAjnsvF4Dg';
-export const CONTINENT_TYPE = '7Jw6Y3vd3SnMCXs2a9MYGu';
-export const COUNTRY_TYPE = '9ECA63EvqWhaoPvbD13ebf';
-export const GOAL_TYPE = '3zr6t9YRRjX7cgSmzgibf8';
-export const JOB_TYPE = 'CCiz2ejCzg5xZuskLD8vda';
-export const NEWS_EVENT_TYPE = 'QAdjgcq9nD7Gv98vn2vrDd';
-export const NEWS_STORY_TYPE = 'VKPGYGnFuaoAASiAukCVCX';
-export const POLICY_TYPE = 'GhaWkvDmMT6KiZTDxRLMXK';
-export const PUBLISHER_TYPE = 'BGCj2JLjDjqUmGW6iZaANK';
-export const QUOTE_TYPE = 'XGsAzMuCVXPtV8e6UfMLd';
-export const REGION_TYPE = 'Qu6vfQq68ecZ4PkihJ4nZN';
-export const SKILL_TYPE = 'LLx1gxshUy1TFKnSKVG9W6';
-export const TAG_TYPE = 'UnP1LtXV3EhrhvRADFcMZK';
-export const TOPIC_TYPE = 'Cj7JSjWKbcdgmUjcLWNR4V';
+import { Id } from '../../id.js';
 
-export const AVATAR_PROPERTY = '399xP4sGWSoepxeEnp3UdR';
+export const ARTICLE_TYPE = Id('M5uDP7nCw3nvfQPUryn9gx');
+export const CITY_TYPE = Id('D6Wy4bdtdoUrG3PDZceHr');
+export const CLAIM_TYPE = Id('KeG9eTM8NUYFMAjnsvF4Dg');
+export const CONTINENT_TYPE = Id('7Jw6Y3vd3SnMCXs2a9MYGu');
+export const COUNTRY_TYPE = Id('9ECA63EvqWhaoPvbD13ebf');
+export const GOAL_TYPE = Id('3zr6t9YRRjX7cgSmzgibf8');
+export const JOB_TYPE = Id('CCiz2ejCzg5xZuskLD8vda');
+export const NEWS_EVENT_TYPE = Id('QAdjgcq9nD7Gv98vn2vrDd');
+export const NEWS_STORY_TYPE = Id('VKPGYGnFuaoAASiAukCVCX');
+export const POLICY_TYPE = Id('GhaWkvDmMT6KiZTDxRLMXK');
+export const PUBLISHER_TYPE = Id('BGCj2JLjDjqUmGW6iZaANK');
+export const QUOTE_TYPE = Id('XGsAzMuCVXPtV8e6UfMLd');
+export const REGION_TYPE = Id('Qu6vfQq68ecZ4PkihJ4nZN');
+export const SKILL_TYPE = Id('LLx1gxshUy1TFKnSKVG9W6');
+export const TAG_TYPE = Id('UnP1LtXV3EhrhvRADFcMZK');
+export const TOPIC_TYPE = Id('Cj7JSjWKbcdgmUjcLWNR4V');
+
+export const AVATAR_PROPERTY = Id('399xP4sGWSoepxeEnp3UdR');
 /*
  * @deprecated use AVATAR_PROPERTY
  */
-export const AVATAR_ATTRIBUTE = '399xP4sGWSoepxeEnp3UdR';
-export const BROADER_GOALS_PROPERTY = 'EtNH2yJmrEK1Mcv7S5MjPN';
+export const AVATAR_ATTRIBUTE = Id('399xP4sGWSoepxeEnp3UdR');
+export const BROADER_GOALS_PROPERTY = Id('EtNH2yJmrEK1Mcv7S5MjPN');
 /*
  * @deprecated use BROADER_GOALS_PROPERTY
  */
-export const BROADER_GOALS_ATTRIBUTE = 'EtNH2yJmrEK1Mcv7S5MjPN';
-export const SUBGOALS_PROPERTY = 'WX9xtsWqFPmAXcTBF833cF';
+export const BROADER_GOALS_ATTRIBUTE = Id('EtNH2yJmrEK1Mcv7S5MjPN');
+export const SUBGOALS_PROPERTY = Id('WX9xtsWqFPmAXcTBF833cF');
 /*
  * @deprecated use SUBGOALS_PROPERTY
  */
-export const SUBGOALS_ATTRIBUTE = 'WX9xtsWqFPmAXcTBF833cF';
-export const DISCLAIMER_PROPERTY = '5zqNJMuTTPzYqhFFQFKJZ4';
+export const SUBGOALS_ATTRIBUTE = Id('WX9xtsWqFPmAXcTBF833cF');
+export const DISCLAIMER_PROPERTY = Id('5zqNJMuTTPzYqhFFQFKJZ4');
 /*
  * @deprecated use DISCLAIMER_PROPERTY
  */
-export const DISCLAIMER_ATTRIBUTE = '5zqNJMuTTPzYqhFFQFKJZ4';
-export const EVENT_DATE_PROPERTY = 'BBA1894NztMD9dWyhiwcsU';
+export const DISCLAIMER_ATTRIBUTE = Id('5zqNJMuTTPzYqhFFQFKJZ4');
+export const EVENT_DATE_PROPERTY = Id('BBA1894NztMD9dWyhiwcsU');
 /*
  * @deprecated use EVENT_DATE_PROPERTY
  */
-export const EVENT_DATE_ATTRIBUTE = 'BBA1894NztMD9dWyhiwcsU';
-export const RELATED_PEOPLE_PROPERTY = 'Cc3AZqRReWs3Zk2W5ALtyw';
+export const EVENT_DATE_ATTRIBUTE = Id('BBA1894NztMD9dWyhiwcsU');
+export const RELATED_PEOPLE_PROPERTY = Id('Cc3AZqRReWs3Zk2W5ALtyw');
 /*
  * @deprecated use RELATED_PEOPLE_PROPERTY
  */
-export const RELATED_PEOPLE_ATTRIBUTE = 'Cc3AZqRReWs3Zk2W5ALtyw';
-export const SKILLS_PROPERTY = 'MCCkmuwQ7PY1GFYpgcmSHv';
+export const RELATED_PEOPLE_ATTRIBUTE = Id('Cc3AZqRReWs3Zk2W5ALtyw');
+export const SKILLS_PROPERTY = Id('MCCkmuwQ7PY1GFYpgcmSHv');
 /*
  * @deprecated use SKILLS_PROPERTY
  */
-export const SKILLS_ATTRIBUTE = 'MCCkmuwQ7PY1GFYpgcmSHv';
-export const ROLES_PROPERTY = 'JkzhbbrXFMfXN7sduMKQRp';
+export const SKILLS_ATTRIBUTE = Id('MCCkmuwQ7PY1GFYpgcmSHv');
+export const ROLES_PROPERTY = Id('JkzhbbrXFMfXN7sduMKQRp');
 /*
  * @deprecated use ROLES_PROPERTY
  */
-export const ROLES_ATTRIBUTE = 'JkzhbbrXFMfXN7sduMKQRp';
-export const HIGHLIGHTED_RELATED_ENTIRIES_PROPERTY = '2HNV2qhhCt314qp6fUDYsJ';
+export const ROLES_ATTRIBUTE = Id('JkzhbbrXFMfXN7sduMKQRp');
+export const HIGHLIGHTED_RELATED_ENTIRIES_PROPERTY = Id('2HNV2qhhCt314qp6fUDYsJ');
 /*
  * @deprecated use HIGHLIGHTED_RELATED_ENTIRIES_PROPERTY
  */
-export const HIGHLIGHTED_RELATED_ENTIRIES_ATTRIBUTE = '2HNV2qhhCt314qp6fUDYsJ';
-export const PUBLISHER_PROPERTY = 'Lc4JrkpMUPhNstqs7mvnc5';
+export const HIGHLIGHTED_RELATED_ENTIRIES_ATTRIBUTE = Id('2HNV2qhhCt314qp6fUDYsJ');
+export const PUBLISHER_PROPERTY = Id('Lc4JrkpMUPhNstqs7mvnc5');
 /*
  * @deprecated use PUBLISHER_PROPERTY
  */
-export const PUBLISHER_ATTRIBUTE = 'Lc4JrkpMUPhNstqs7mvnc5';
-export const AUTHORS_PROPERTY = 'JzFpgguvcCaKhbQYPHsrNT';
+export const PUBLISHER_ATTRIBUTE = Id('Lc4JrkpMUPhNstqs7mvnc5');
+export const AUTHORS_PROPERTY = Id('JzFpgguvcCaKhbQYPHsrNT');
 /*
  * @deprecated use AUTHORS_PROPERTY
  */
-export const AUTHORS_ATTRIBUTE = 'JzFpgguvcCaKhbQYPHsrNT';
-export const WEB_ARCHIVE_URL_PROPERTY = 'BTNv9aAFqAzDjQuf4u2fXK';
+export const AUTHORS_ATTRIBUTE = Id('JzFpgguvcCaKhbQYPHsrNT');
+export const WEB_ARCHIVE_URL_PROPERTY = Id('BTNv9aAFqAzDjQuf4u2fXK');
 /*
  * @deprecated use WEB_ARCHIVE_URL_PROPERTY
  */
-export const WEB_ARCHIVE_URL_ATTRIBUTE = 'BTNv9aAFqAzDjQuf4u2fXK';
-export const PUBLISH_DATE_PROPERTY = 'KPNjGaLx5dKofVhT6Dfw22';
+export const WEB_ARCHIVE_URL_ATTRIBUTE = Id('BTNv9aAFqAzDjQuf4u2fXK');
+export const PUBLISH_DATE_PROPERTY = Id('KPNjGaLx5dKofVhT6Dfw22');
 /*
  * @deprecated use PUBLISH_DATE_PROPERTY
  */
-export const PUBLISH_DATE_ATTRIBUTE = 'KPNjGaLx5dKofVhT6Dfw22';
-export const OWNERS_PROPERTY = 'RwDfM3vUvyLwSNYv6sWhc9';
+export const PUBLISH_DATE_ATTRIBUTE = Id('KPNjGaLx5dKofVhT6Dfw22');
+export const OWNERS_PROPERTY = Id('RwDfM3vUvyLwSNYv6sWhc9');
 /*
  * @deprecated use OWNERS_PROPERTY
  */
-export const OWNERS_ATTRIBUTE = 'RwDfM3vUvyLwSNYv6sWhc9';
-export const SOURCES_PROPERTY = 'A7NJF2WPh8VhmvbfVWiyLo';
+export const OWNERS_ATTRIBUTE = Id('RwDfM3vUvyLwSNYv6sWhc9');
+export const SOURCES_PROPERTY = Id('A7NJF2WPh8VhmvbfVWiyLo');
 /*
  * @deprecated use SOURCES_PROPERTY
  */
-export const SOURCES_ATTRIBUTE = 'A7NJF2WPh8VhmvbfVWiyLo';
-export const QUOTES_THAT_SUPPORT_CLAIMS_PROPERTY = 'quotesThatSupportClaims';
+export const SOURCES_ATTRIBUTE = Id('A7NJF2WPh8VhmvbfVWiyLo');
+export const QUOTES_THAT_SUPPORT_CLAIMS_PROPERTY = Id('WoWTti3qGM1nvz28K9zu1f');
 /*
  * @deprecated use QUOTES_THAT_SUPPORT_CLAIMS_PROPERTY
  */
-export const QUOTES_THAT_SUPPORT_CLAIMS_ATTRIBUTE = 'quotesThatSupportClaims';
-export const OPPOSING_ARGUMENTS_PROPERTY = 'Agk2hbiBWsgHVXxpFAc7z5';
+export const QUOTES_THAT_SUPPORT_CLAIMS_ATTRIBUTE = Id('WoWTti3qGM1nvz28K9zu1f');
+export const OPPOSING_ARGUMENTS_PROPERTY = Id('Agk2hbiBWsgHVXxpFAc7z5');
 /*
  * @deprecated use OPPOSING_ARGUMENTS_PROPERTY
  */
-export const OPPOSING_ARGUMENTS_ATTRIBUTE = 'Agk2hbiBWsgHVXxpFAc7z5';
-export const SUPPORTING_ARGUMENTS_PROPERTY = '4gFz5SYHWkBJoAANfCt61v';
+export const OPPOSING_ARGUMENTS_ATTRIBUTE = Id('Agk2hbiBWsgHVXxpFAc7z5');
+export const SUPPORTING_ARGUMENTS_PROPERTY = Id('4gFz5SYHWkBJoAANfCt61v');
 /*
  * @deprecated use SUPPORTING_ARGUMENTS_PROPERTY
  */
-export const SUPPORTING_ARGUMENTS_ATTRIBUTE = '4gFz5SYHWkBJoAANfCt61v';
-export const WEBSITE_PROPERTY = 'WVVjk5okbvLspwdY1iTmwp';
+export const SUPPORTING_ARGUMENTS_ATTRIBUTE = Id('4gFz5SYHWkBJoAANfCt61v');
+export const WEBSITE_PROPERTY = Id('WVVjk5okbvLspwdY1iTmwp');
 /*
  * @deprecated use WEBSITE_PROPERTY
  */
-export const WEBSITE_ATTRIBUTE = 'WVVjk5okbvLspwdY1iTmwp';
-export const BROADER_PROJECTS_PROPERTY = '62X1RkFCmH7vC7WR4JzRrk';
+export const WEBSITE_ATTRIBUTE = Id('WVVjk5okbvLspwdY1iTmwp');
+export const BROADER_PROJECTS_PROPERTY = Id('62X1RkFCmH7vC7WR4JzRrk');
 /*
  * @deprecated use BROADER_PROJECTS_PROPERTY
  */
-export const BROADER_PROJECTS_ATTRIBUTE = '62X1RkFCmH7vC7WR4JzRrk';
-export const SUBPROJECTS_PROPERTY = 'HCF2yGBEqcS8chspMNmoPY';
+export const BROADER_PROJECTS_ATTRIBUTE = Id('62X1RkFCmH7vC7WR4JzRrk');
+export const SUBPROJECTS_PROPERTY = Id('HCF2yGBEqcS8chspMNmoPY');
 /*
  * @deprecated use SUBPROJECTS_PROPERTY
  */
-export const SUBPROJECTS_ATTRIBUTE = 'HCF2yGBEqcS8chspMNmoPY';
-export const TOPICS_PROPERTY = '9bCuX6B9KZDSaY8xtghNZo';
+export const SUBPROJECTS_ATTRIBUTE = Id('HCF2yGBEqcS8chspMNmoPY');
+export const TOPICS_PROPERTY = Id('9bCuX6B9KZDSaY8xtghNZo');
 /*
  * @deprecated use TOPICS_PROPERTY
  */
-export const TOPICS_ATTRIBUTE = '9bCuX6B9KZDSaY8xtghNZo';
-export const RELATED_ENTITIES_PROPERTY = 'UcouYcgu8qhine1WCXkZEb';
+export const TOPICS_ATTRIBUTE = Id('9bCuX6B9KZDSaY8xtghNZo');
+export const RELATED_ENTITIES_PROPERTY = Id('UcouYcgu8qhine1WCXkZEb');
 /*
  * @deprecated use RELATED_ENTITIES_PROPERTY
  */
-export const RELATED_ENTITIES_ATTRIBUTE = 'UcouYcgu8qhine1WCXkZEb';
-export const X_PROPERTY = '2eroVfdaXQEUw314r5hr35';
+export const RELATED_ENTITIES_ATTRIBUTE = Id('UcouYcgu8qhine1WCXkZEb');
+export const X_PROPERTY = Id('2eroVfdaXQEUw314r5hr35');
 /*
  * @deprecated use X_PROPERTY
  */
-export const X_ATTRIBUTE = '2eroVfdaXQEUw314r5hr35';
-export const CITIES_PROPERTY = '5GBCRqS8HYqiBubFPy5aXk';
+export const X_ATTRIBUTE = Id('2eroVfdaXQEUw314r5hr35');
+export const CITIES_PROPERTY = Id('5GBCRqS8HYqiBubFPy5aXk');
 /*
  * @deprecated use CITIES_PROPERTY
  */
-export const CITIES_ATTRIBUTE = '5GBCRqS8HYqiBubFPy5aXk';
-export const LOCATION_PROPERTY = 'KWBLj9czHBBmYUT98rnxVM';
+export const CITIES_ATTRIBUTE = Id('5GBCRqS8HYqiBubFPy5aXk');
+export const LOCATION_PROPERTY = Id('KWBLj9czHBBmYUT98rnxVM');
 /*
  * @deprecated use LOCATION_PROPERTY
  */
-export const LOCATION_ATTRIBUTE = 'KWBLj9czHBBmYUT98rnxVM';
-export const WEB_URL_PROPERTY = '93stf6cgYvBsdPruRzq1KK';
+export const LOCATION_ATTRIBUTE = Id('KWBLj9czHBBmYUT98rnxVM');
+export const WEB_URL_PROPERTY = Id('93stf6cgYvBsdPruRzq1KK');
 /*
  * @deprecated use WEB_URL_PROPERTY
  */
-export const WEB_URL_ATTRIBUTE = '93stf6cgYvBsdPruRzq1KK';
-export const SUBTOPICS_PROPERTY = '89cuddDgriDAZJV6oy8zmt';
+export const WEB_URL_ATTRIBUTE = Id('93stf6cgYvBsdPruRzq1KK');
+export const SUBTOPICS_PROPERTY = Id('89cuddDgriDAZJV6oy8zmt');
 /*
  * @deprecated use SUBTOPICS_PROPERTY
  */
-export const SUBTOPICS_ATTRIBUTE = '89cuddDgriDAZJV6oy8zmt';
-export const RELATED_TOPICS_PROPERTY = 'GrojMdwbutDvrciUgcL2e4';
+export const SUBTOPICS_ATTRIBUTE = Id('89cuddDgriDAZJV6oy8zmt');
+export const RELATED_TOPICS_PROPERTY = Id('GrojMdwbutDvrciUgcL2e4');
 /*
  * @deprecated use RELATED_TOPICS_PROPERTY
  */
-export const RELATED_TOPICS_ATTRIBUTE = 'GrojMdwbutDvrciUgcL2e4';
-export const COUNTRIES_PROPERTY = 'RJNy4SeZSHMnpqXt3Jj5iM';
+export const RELATED_TOPICS_ATTRIBUTE = Id('GrojMdwbutDvrciUgcL2e4');
+export const COUNTRIES_PROPERTY = Id('RJNy4SeZSHMnpqXt3Jj5iM');
 /*
  * @deprecated use COUNTRIES_PROPERTY
  */
-export const COUNTRIES_ATTRIBUTE = 'RJNy4SeZSHMnpqXt3Jj5iM';
-export const BROADER_TOPICS_PROPERTY = 'P9apCagMDXQVdjgAZftxU5';
+export const COUNTRIES_ATTRIBUTE = Id('RJNy4SeZSHMnpqXt3Jj5iM');
+export const BROADER_TOPICS_PROPERTY = Id('P9apCagMDXQVdjgAZftxU5');
 /*
  * @deprecated use BROADER_TOPICS_PROPERTY
  */
-export const BROADER_TOPICS_ATTRIBUTE = 'P9apCagMDXQVdjgAZftxU5';
-export const RELATED_PROJECTS_PROPERTY = 'EcK9J1zwDzSQPTnBRcUg2A';
+export const BROADER_TOPICS_ATTRIBUTE = Id('P9apCagMDXQVdjgAZftxU5');
+export const RELATED_PROJECTS_PROPERTY = Id('EcK9J1zwDzSQPTnBRcUg2A');
 /*
  * @deprecated use RELATED_PROJECTS_PROPERTY
  */
-export const RELATED_PROJECTS_ATTRIBUTE = 'EcK9J1zwDzSQPTnBRcUg2A';
-export const CONTINENTS_PROPERTY = '4W6gL14KsToDLy5yUEdawU';
+export const RELATED_PROJECTS_ATTRIBUTE = Id('EcK9J1zwDzSQPTnBRcUg2A');
+export const CONTINENTS_PROPERTY = Id('4W6gL14KsToDLy5yUEdawU');
 /*
  * @deprecated use CONTINENTS_PROPERTY
  */
-export const CONTINENTS_ATTRIBUTE = '4W6gL14KsToDLy5yUEdawU';
-export const PERSON_PROPERTY = 'W2aFZPy5nnU3DgdkWJCNVn';
+export const CONTINENTS_ATTRIBUTE = Id('4W6gL14KsToDLy5yUEdawU');
+export const PERSON_PROPERTY = Id('W2aFZPy5nnU3DgdkWJCNVn');
 /*
  * @deprecated use PERSON_PROPERTY
  */
-export const PERSON_ATTRIBUTE = 'W2aFZPy5nnU3DgdkWJCNVn';
-export const PROJECT_PROPERTY = 'V7XvcnLXtbj7T2rvdNtKid';
+export const PERSON_ATTRIBUTE = Id('W2aFZPy5nnU3DgdkWJCNVn');
+export const PROJECT_PROPERTY = Id('V7XvcnLXtbj7T2rvdNtKid');
 /*
  * @deprecated use PROJECT_PROPERTY
  */
-export const PROJECT_ATTRIBUTE = 'V7XvcnLXtbj7T2rvdNtKid';
-export const RELATED_SPACES_PROPERTY = 'CHwmK8bk4KMCqBNiV2waL9';
+export const PROJECT_ATTRIBUTE = Id('V7XvcnLXtbj7T2rvdNtKid');
+export const RELATED_SPACES_PROPERTY = Id('CHwmK8bk4KMCqBNiV2waL9');
 /*
  * @deprecated use RELATED_SPACES_PROPERTY
  */
-export const RELATED_SPACES_ATTRIBUTE = 'CHwmK8bk4KMCqBNiV2waL9';
+export const RELATED_SPACES_ATTRIBUTE = Id('CHwmK8bk4KMCqBNiV2waL9');
 
 /**
  * Migration 1
  */
-export const VALUE_TYPE = 'Y1HG66QvvthrmL3dredT53';
-export const PRINCIPLE_TYPE = '2tjghBgapq2CNRsUPMhZ5b';
+export const VALUE_TYPE = Id('Y1HG66QvvthrmL3dredT53');
+export const PRINCIPLE_TYPE = Id('2tjghBgapq2CNRsUPMhZ5b');

--- a/src/core/ids/network.ts
+++ b/src/core/ids/network.ts
@@ -1,3 +1,5 @@
-export const POLYGON = 'ReFDxuVQ674gHd2kFjsFL';
-export const ETHEREUM = 'JnWfsCw2gqoPWFT1NXmFWW';
-export const GEO = 'KJjKetFsGVSbw9qFpRzRSy';
+import { Id } from '../../id.js';
+
+export const POLYGON = Id('ReFDxuVQ674gHd2kFjsFL');
+export const ETHEREUM = Id('JnWfsCw2gqoPWFT1NXmFWW');
+export const GEO = Id('KJjKetFsGVSbw9qFpRzRSy');

--- a/src/core/ids/system.ts
+++ b/src/core/ids/system.ts
@@ -1,103 +1,105 @@
-export const PROPERTY = 'GscJ2GELQjmLoaVrYyR3xm';
+import { Id } from '../../id.js';
+
+export const PROPERTY = Id('GscJ2GELQjmLoaVrYyR3xm');
 /**
  * @deprecated use PROPERTY
  */
-export const ATTRIBUTE = 'GscJ2GELQjmLoaVrYyR3xm';
-export const SCHEMA_TYPE = 'VdTsW1mGiy1XSooJaBBLc4';
-export const PROPERTIES = '9zBADaYzyfzyFJn4GU1cC';
+export const ATTRIBUTE = Id('GscJ2GELQjmLoaVrYyR3xm');
+export const SCHEMA_TYPE = Id('VdTsW1mGiy1XSooJaBBLc4');
+export const PROPERTIES = Id('9zBADaYzyfzyFJn4GU1cC');
 
-export const NAME_PROPERTY = 'LuBWqZAu6pz54eiJS5mLv8';
+export const NAME_PROPERTY = Id('LuBWqZAu6pz54eiJS5mLv8');
 /*
  * @deprecated use NAME_PROPERTY
  */
-export const NAME_ATTRIBUTE = 'LuBWqZAu6pz54eiJS5mLv8';
-export const DESCRIPTION_PROPERTY = 'LA1DqP5v6QAdsgLPXGF3YA';
+export const NAME_ATTRIBUTE = Id('LuBWqZAu6pz54eiJS5mLv8');
+export const DESCRIPTION_PROPERTY = Id('LA1DqP5v6QAdsgLPXGF3YA');
 /*
  * @deprecated use DESCRIPTION_PROPERTY
  */
-export const DESCRIPTION_ATTRIBUTE = 'LA1DqP5v6QAdsgLPXGF3YA';
-export const COVER_PROPERTY = '7YHk6qYkNDaAtNb8GwmysF';
+export const DESCRIPTION_ATTRIBUTE = Id('LA1DqP5v6QAdsgLPXGF3YA');
+export const COVER_PROPERTY = Id('7YHk6qYkNDaAtNb8GwmysF');
 /*
  * @deprecated use COVER_PROPERTY
  */
-export const COVER_ATTRIBUTE = '7YHk6qYkNDaAtNb8GwmysF';
-export const TYPES_PROPERTY = 'Jfmby78N4BCseZinBmdVov';
+export const COVER_ATTRIBUTE = Id('7YHk6qYkNDaAtNb8GwmysF');
+export const TYPES_PROPERTY = Id('Jfmby78N4BCseZinBmdVov');
 /*
  * @deprecated use TYPES_PROPERTY
  */
-export const TYPES_ATTRIBUTE = 'Jfmby78N4BCseZinBmdVov';
-export const TABS_PROPERTY = 'AasCPmGHxVcsswE9PzmNT4';
+export const TYPES_ATTRIBUTE = Id('Jfmby78N4BCseZinBmdVov');
+export const TABS_PROPERTY = Id('AasCPmGHxVcsswE9PzmNT4');
 /*
  * @deprecated use TABS_PROPERTY
  */
-export const TABS_ATTRIBUTE = 'AasCPmGHxVcsswE9PzmNT4';
-export const BLOCKS = 'QYbjCM6NT9xmh2hFGsqpQX';
+export const TABS_ATTRIBUTE = Id('AasCPmGHxVcsswE9PzmNT4');
+export const BLOCKS = Id('QYbjCM6NT9xmh2hFGsqpQX');
 
 /** Value types */
 
-export const VALUE_TYPE_PROPERTY = 'WQfdWjboZWFuTseDhG5Cw1';
+export const VALUE_TYPE_PROPERTY = Id('WQfdWjboZWFuTseDhG5Cw1');
 /*
  * @deprecated use VALUE_TYPE_PROPERTY
  */
-export const VALUE_TYPE_ATTRIBUTE = 'WQfdWjboZWFuTseDhG5Cw1';
-export const CHECKBOX = 'G9NpD4c7GB7nH5YU9Tesgf';
-export const TIME = '3mswMrL91GuYTfBq29EuNE';
-export const TEXT = 'LckSTmjBrYAJaFcDs89am5';
-export const URL = '5xroh3gbWYbWY4oR3nFXzy';
-export const NUMBER = 'LBdMpTNyycNffsF51t2eSp';
-export const POINT = 'UZBZNbA7Uhx1f8ebLi1Qj5';
-export const IMAGE = 'X8KB1uF84RYppghBSVvhqr';
+export const VALUE_TYPE_ATTRIBUTE = Id('WQfdWjboZWFuTseDhG5Cw1');
+export const CHECKBOX = Id('G9NpD4c7GB7nH5YU9Tesgf');
+export const TIME = Id('3mswMrL91GuYTfBq29EuNE');
+export const TEXT = Id('LckSTmjBrYAJaFcDs89am5');
+export const URL = Id('5xroh3gbWYbWY4oR3nFXzy');
+export const NUMBER = Id('LBdMpTNyycNffsF51t2eSp');
+export const POINT = Id('UZBZNbA7Uhx1f8ebLi1Qj5');
+export const IMAGE = Id('X8KB1uF84RYppghBSVvhqr');
 
-export const RELATION = 'AKDxovGvZaPSWnmKnSoZJY';
+export const RELATION = Id('AKDxovGvZaPSWnmKnSoZJY');
 
-export const SPACE_TYPE = '7gzF671tq5JTZ13naG4tnr';
+export const SPACE_TYPE = Id('7gzF671tq5JTZ13naG4tnr');
 
 /**
  * Defines the relation value types for a relation. e.g., a Persons
  * attribute must only contain relations where the to entity is type
  * Person
  */
-export const RELATION_VALUE_RELATIONSHIP_TYPE = 'LdAS7yWqF32E2J4doUDe5u';
+export const RELATION_VALUE_RELATIONSHIP_TYPE = Id('LdAS7yWqF32E2J4doUDe5u');
 
-export const IMAGE_TYPE = 'Q1LaZhnzj8AtCzx8T1HRMf';
-export const IMAGE_FILE_TYPE_PROPERTY = 'B3nyKkmERhFEcaVgoe6kAL';
+export const IMAGE_TYPE = Id('Q1LaZhnzj8AtCzx8T1HRMf');
+export const IMAGE_FILE_TYPE_PROPERTY = Id('B3nyKkmERhFEcaVgoe6kAL');
 /*
  * @deprecated use IMAGE_FILE_TYPE_PROPERTY
  */
-export const IMAGE_FILE_TYPE_ATTRIBUTE = 'B3nyKkmERhFEcaVgoe6kAL';
-export const IMAGE_HEIGHT_PROPERTY = 'GjaFuBBB8z63y9qr8dhaSP';
+export const IMAGE_FILE_TYPE_ATTRIBUTE = Id('B3nyKkmERhFEcaVgoe6kAL');
+export const IMAGE_HEIGHT_PROPERTY = Id('GjaFuBBB8z63y9qr8dhaSP');
 /*
  * @deprecated use IMAGE_HEIGHT_PROPERTY
  */
-export const IMAGE_HEIGHT_ATTRIBUTE = 'GjaFuBBB8z63y9qr8dhaSP';
-export const IMAGE_URL_PROPERTY = 'J6cw1v8xUHCFsEdPeuB1Uo';
+export const IMAGE_HEIGHT_ATTRIBUTE = Id('GjaFuBBB8z63y9qr8dhaSP');
+export const IMAGE_URL_PROPERTY = Id('J6cw1v8xUHCFsEdPeuB1Uo');
 /*
  * @deprecated use IMAGE_URL_PROPERTY
  */
-export const IMAGE_URL_ATTRIBUTE = 'J6cw1v8xUHCFsEdPeuB1Uo';
-export const IMAGE_WIDTH_PROPERTY = 'Xb3useEUkWV1Y9zYYkq4xp';
+export const IMAGE_URL_ATTRIBUTE = Id('J6cw1v8xUHCFsEdPeuB1Uo');
+export const IMAGE_WIDTH_PROPERTY = Id('Xb3useEUkWV1Y9zYYkq4xp');
 /*
  * @deprecated use IMAGE_WIDTH_PROPERTY
  */
-export const IMAGE_WIDTH_ATTRIBUTE = 'Xb3useEUkWV1Y9zYYkq4xp';
+export const IMAGE_WIDTH_ATTRIBUTE = Id('Xb3useEUkWV1Y9zYYkq4xp');
 
 /** Data blocks */
 // @TODO: data block instead of TABLE_BLOCK
-export const DATA_BLOCK = 'PnQsGwnnztrLNRCm9mcKKY';
-export const DATA_SOURCE_PROPERTY = 'J8nmVHZDeCLNhPxX7qyEZG';
+export const DATA_BLOCK = Id('PnQsGwnnztrLNRCm9mcKKY');
+export const DATA_SOURCE_PROPERTY = Id('J8nmVHZDeCLNhPxX7qyEZG');
 /*
  * @deprecated use DATA_SOURCE_PROPERTY
  */
-export const DATA_SOURCE_ATTRIBUTE = 'J8nmVHZDeCLNhPxX7qyEZG';
-export const ALL_OF_GEO_DATA_SOURCE = 'XqDkiYjqEufsbjqegxkqZU';
-export const COLLECTION_DATA_SOURCE = '3J6223VX6MkwTftWdzDfo4';
-export const QUERY_DATA_SOURCE = '8HkP7HCufp2HcCFajuJFcq';
+export const DATA_SOURCE_ATTRIBUTE = Id('J8nmVHZDeCLNhPxX7qyEZG');
+export const ALL_OF_GEO_DATA_SOURCE = Id('XqDkiYjqEufsbjqegxkqZU');
+export const COLLECTION_DATA_SOURCE = Id('3J6223VX6MkwTftWdzDfo4');
+export const QUERY_DATA_SOURCE = Id('8HkP7HCufp2HcCFajuJFcq');
 
-export const SELECTOR_PROPERTY = '7zvaXnZVY9z5oCoYqciroz';
+export const SELECTOR_PROPERTY = Id('7zvaXnZVY9z5oCoYqciroz');
 /*
  * @deprecated use SELECTOR_PROPERTY
  */
-export const SELECTOR_ATTRIBUTE = '7zvaXnZVY9z5oCoYqciroz';
+export const SELECTOR_ATTRIBUTE = Id('7zvaXnZVY9z5oCoYqciroz');
 
 /**
  * Defines the filters applied to a data block. It applies whether
@@ -105,9 +107,9 @@ export const SELECTOR_ATTRIBUTE = '7zvaXnZVY9z5oCoYqciroz';
  *
  * See the Filters spec to see the Filter format.
  */
-export const FILTER = '3YqoLJ7uAPmthXyXmXKoSa';
-export const SPACE_FILTER = 'JiFmyuFYeoiRSiY286m7A2';
-export const ENTITY_FILTER = 'TWrUhTe6E8tKCJr9vfCzxT';
+export const FILTER = Id('3YqoLJ7uAPmthXyXmXKoSa');
+export const SPACE_FILTER = Id('JiFmyuFYeoiRSiY286m7A2');
+export const ENTITY_FILTER = Id('TWrUhTe6E8tKCJr9vfCzxT');
 
 /**
  * Defines that a relation type is COLLECTION_ITEM. This is used by
@@ -118,7 +120,7 @@ export const ENTITY_FILTER = 'TWrUhTe6E8tKCJr9vfCzxT';
  * rather than the results of a query. A collection item defines what
  * these selected entities are.
  */
-export const COLLECTION_ITEM_RELATION_TYPE = 'Mwrn46KavwfWgNrFaWcB9j';
+export const COLLECTION_ITEM_RELATION_TYPE = Id('Mwrn46KavwfWgNrFaWcB9j');
 
 /**
  * Defines the view type for a data block, either a {@link TABLE_VIEW},
@@ -128,33 +130,33 @@ export const COLLECTION_ITEM_RELATION_TYPE = 'Mwrn46KavwfWgNrFaWcB9j';
  * This view data lives on the relation pointing to the block. This enables
  * different consumers of the data block to define their own views.
  */
-export const VIEW_PROPERTY = '46GzPiTRPG36jX9dmNE9ic';
+export const VIEW_PROPERTY = Id('46GzPiTRPG36jX9dmNE9ic');
 /*
  * @deprecated use VIEW_PROPERTY
  */
-export const VIEW_ATTRIBUTE = '46GzPiTRPG36jX9dmNE9ic';
+export const VIEW_ATTRIBUTE = Id('46GzPiTRPG36jX9dmNE9ic');
 
-export const VIEW_TYPE = '52itq1wC2HciX6gd9HEZPN';
-export const TABLE_VIEW = 'S9T1TPras3iPkVvrS5CoKE';
-export const LIST_VIEW = 'GUKPGARFBFBMoET6NGQctJ';
-export const GALLERY_VIEW = 'SHBs5faKV8gDeZgsUoVUQF';
+export const VIEW_TYPE = Id('52itq1wC2HciX6gd9HEZPN');
+export const TABLE_VIEW = Id('S9T1TPras3iPkVvrS5CoKE');
+export const LIST_VIEW = Id('GUKPGARFBFBMoET6NGQctJ');
+export const GALLERY_VIEW = Id('SHBs5faKV8gDeZgsUoVUQF');
 
 /**
  * Defines the columns to show on a data block when in {@link TABLE_VIEW}.
  */
-export const SHOWN_COLUMNS = '9AecPe8JTN7uJRaX1Mk1XV';
+export const SHOWN_COLUMNS = Id('9AecPe8JTN7uJRaX1Mk1XV');
 
 /**
  * Defines the type of data source for a data block, either a
  * {@link COLLECTION_DATA_SOURCE}, an {@link ALL_OF_GEO_DATA_SOURCE} or
  * a {@link QUERY_DATA_SOURCE}
  */
-export const DATA_SOURCE_TYPE_RELATION_TYPE = '4sz7Kx91uq4KBW5sohjLkj';
+export const DATA_SOURCE_TYPE_RELATION_TYPE = Id('4sz7Kx91uq4KBW5sohjLkj');
 
-export const IMAGE_BLOCK = 'V6R8hWrKfLZmtyv4dQyyzo';
-export const TEXT_BLOCK = 'Fc836HBAyTaLaZgBzcTS2a';
+export const IMAGE_BLOCK = Id('V6R8hWrKfLZmtyv4dQyyzo');
+export const TEXT_BLOCK = Id('Fc836HBAyTaLaZgBzcTS2a');
 
-export const MARKDOWN_CONTENT = 'V9A2298ZHL135zFRH4qcRg';
+export const MARKDOWN_CONTENT = Id('V9A2298ZHL135zFRH4qcRg');
 
 /**
  * Relations define an entity which represents a relationship between
@@ -168,29 +170,29 @@ export const MARKDOWN_CONTENT = 'V9A2298ZHL135zFRH4qcRg';
  * marriage itself, and not John or Jane. This representation of the
  * marriage also only exists in the context of John and Jane.
  */
-export const RELATION_TYPE = 'QtC4Ay8HNLwSd1kSARgcDE';
-export const RELATION_FROM_PROPERTY = 'RERshk4JoYoMC17r1qAo9J';
+export const RELATION_TYPE = Id('QtC4Ay8HNLwSd1kSARgcDE');
+export const RELATION_FROM_PROPERTY = Id('RERshk4JoYoMC17r1qAo9J');
 /*
  * @deprecated use RELATION_FROM_PROPERTY
  */
-export const RELATION_FROM_ATTRIBUTE = 'RERshk4JoYoMC17r1qAo9J';
-export const RELATION_TO_PROPERTY = 'Qx8dASiTNsxxP3rJbd4Lzd';
+export const RELATION_FROM_ATTRIBUTE = Id('RERshk4JoYoMC17r1qAo9J');
+export const RELATION_TO_PROPERTY = Id('Qx8dASiTNsxxP3rJbd4Lzd');
 /*
  * @deprecated use RELATION_TO_PROPERTY
  */
-export const RELATION_TO_ATTRIBUTE = 'Qx8dASiTNsxxP3rJbd4Lzd';
-export const RELATION_TYPE_PROPERTY = '3WxYoAVreE4qFhkDUs5J3q';
+export const RELATION_TO_ATTRIBUTE = Id('Qx8dASiTNsxxP3rJbd4Lzd');
+export const RELATION_TYPE_PROPERTY = Id('3WxYoAVreE4qFhkDUs5J3q');
 /*
  * @deprecated use RELATION_TYPE_PROPERTY
  */
-export const RELATION_TYPE_ATTRIBUTE = '3WxYoAVreE4qFhkDUs5J3q';
+export const RELATION_TYPE_ATTRIBUTE = Id('3WxYoAVreE4qFhkDUs5J3q');
 /*
  * Relations can be ordered using fractional indexing. By default we
  * add an index to every relation so that ordering can be added to
  * any relation at any point without having to add indexes to relations
  * post-creation.
  */
-export const RELATION_INDEX = 'WNopXUYxsSsE51gkJGWghe';
+export const RELATION_INDEX = Id('WNopXUYxsSsE51gkJGWghe');
 
 /**
  * Defines whether a relation has been "verified." Verification can
@@ -205,212 +207,212 @@ export const RELATION_INDEX = 'WNopXUYxsSsE51gkJGWghe';
  * is the correct one to represent this Person from the perspective
  * of the current space.
  */
-export const VERIFIED_SOURCE_PROPERTY = '5jodArZNFzucsYzQaDVFBL';
+export const VERIFIED_SOURCE_PROPERTY = Id('5jodArZNFzucsYzQaDVFBL');
 /*
  * @deprecated use VERIFIED_SOURCE_PROPERTY
  */
-export const VERIFIED_SOURCE_ATTRIBUTE = '5jodArZNFzucsYzQaDVFBL';
-export const SOURCE_SPACE_PROPERTY = 'GzkEQP3yedWjXE8QPFKEwV';
+export const VERIFIED_SOURCE_ATTRIBUTE = Id('5jodArZNFzucsYzQaDVFBL');
+export const SOURCE_SPACE_PROPERTY = Id('GzkEQP3yedWjXE8QPFKEwV');
 /*
  * @deprecated use SOURCE_SPACE_PROPERTY
  */
-export const SOURCE_SPACE_ATTRIBUTE = 'GzkEQP3yedWjXE8QPFKEwV';
+export const SOURCE_SPACE_ATTRIBUTE = Id('GzkEQP3yedWjXE8QPFKEwV');
 
 /** Core types */
-export const ACADEMIC_FIELD_TYPE = 'ExCjm3rzYVfpMRwDchdrE';
-export const COMPANY_TYPE = 'UhpHYoFEzAov9WwqtDwQk4';
-export const DAO_TYPE = 'Hh8hc47TMBvRsD4oqUNxP9';
-export const GOVERNMENT_ORG_TYPE = 'MokrHqV4jZhBfPN3mLPjM8';
-export const INDUSTRY_TYPE = 'YA7mhzaafD2vnjekmcnLER';
-export const INTEREST_TYPE = '6VSi54UDKnL34BWHBqdzee';
-export const NONPROFIT_TYPE = 'RemzN69c24othsp2rP7yMX';
-export const POST_TYPE = 'X7KuZJQewaCiCy9QV2vjyv';
-export const PROJECT_TYPE = '9vk7Q3pz7US3s2KePFQrJT';
-export const PROTOCOL_TYPE = 'R9Xo87Q6oaxfSBrHvVQFdS';
-export const REGION_TYPE = 'Qu6vfQq68ecZ4PkihJ4nZN';
-export const ROOT_SPACE_TYPE = 'k7vbnMPxzdtGL2J3uaB6d';
+export const ACADEMIC_FIELD_TYPE = Id('KwKGhkY5AmzmHHggg7abvi');
+export const COMPANY_TYPE = Id('UhpHYoFEzAov9WwqtDwQk4');
+export const DAO_TYPE = Id('Hh8hc47TMBvRsD4oqUNxP9');
+export const GOVERNMENT_ORG_TYPE = Id('MokrHqV4jZhBfPN3mLPjM8');
+export const INDUSTRY_TYPE = Id('YA7mhzaafD2vnjekmcnLER');
+export const INTEREST_TYPE = Id('6VSi54UDKnL34BWHBqdzee');
+export const NONPROFIT_TYPE = Id('RemzN69c24othsp2rP7yMX');
+export const POST_TYPE = Id('X7KuZJQewaCiCy9QV2vjyv');
+export const PROJECT_TYPE = Id('9vk7Q3pz7US3s2KePFQrJT');
+export const PROTOCOL_TYPE = Id('R9Xo87Q6oaxfSBrHvVQFdS');
+export const REGION_TYPE = Id('Qu6vfQq68ecZ4PkihJ4nZN');
+export const ROOT_SPACE_TYPE = Id('k7vbnMPxzdtGL2J3uaB6d');
 
 /** Templates */
-export const TEMPLATE_PROPERTY = 'Sb7ZvdGsCDm2r1mNZBA5ft';
+export const TEMPLATE_PROPERTY = Id('Sb7ZvdGsCDm2r1mNZBA5ft');
 /*
  * @deprecated use TEMPLATE_PROPERTY
  */
-export const TEMPLATE_ATTRIBUTE = 'Sb7ZvdGsCDm2r1mNZBA5ft';
-export const PAGE_TYPE = '9u4zseS3EDXG9ZvwR9RmqU';
+export const TEMPLATE_ATTRIBUTE = Id('Sb7ZvdGsCDm2r1mNZBA5ft');
+export const PAGE_TYPE = Id('9u4zseS3EDXG9ZvwR9RmqU');
 /**
  * Defines the page type for a template. e.g., an events page, a
  * finances page, a products page, etc.
  */
-export const PAGE_TYPE_PROPERTY = 'DD9FKRZ3XezaKEGUszMB3r';
+export const PAGE_TYPE_PROPERTY = Id('DD9FKRZ3XezaKEGUszMB3r');
 /*
  * @deprecated use PAGE_TYPE_PROPERTY
  */
-export const PAGE_TYPE_ATTRIBUTE = 'DD9FKRZ3XezaKEGUszMB3r';
+export const PAGE_TYPE_ATTRIBUTE = Id('DD9FKRZ3XezaKEGUszMB3r');
 
 /**
   These define the entity id to copy when creating an entity from
   a template.
   */
-export const ACADEMIC_FIELD_TEMPLATE = 'qKChmTLcV1itqfQeGeYVv';
-export const COMPANY_TEMPLATE = 'QZwChwTixtbLDv3HSX5E6n';
-export const DAO_TEMPLATE = 'Gfj89RHeFexx36V5kN6LhB';
-export const INDUSTRY_TEMPLATE = 'Tgm2ubmm9VjAZFZACJLTZC';
-export const INTEREST_TEMPLATE = 'C7XkQKqhRHv28Uuo5m2DZP';
-export const NONPROFIT_TEMPLATE = 'HEuj9VYAF5z1KQ8x37Uzze';
-export const PERSON_TEMPLATE = 'EJuFuEz17wdVCk9ctEAkW7';
-export const PROTOCOL_TEMPLATE = 'UKKzBPkwY51qcVB9QTLNB6';
-export const REGION_TEMPLATE = 'RL8uWpewpYdcmJ3rjoudjT';
+export const ACADEMIC_FIELD_TEMPLATE = Id('qKChmTLcV1itqfQeGeYVv');
+export const COMPANY_TEMPLATE = Id('QZwChwTixtbLDv3HSX5E6n');
+export const DAO_TEMPLATE = Id('Gfj89RHeFexx36V5kN6LhB');
+export const INDUSTRY_TEMPLATE = Id('Tgm2ubmm9VjAZFZACJLTZC');
+export const INTEREST_TEMPLATE = Id('C7XkQKqhRHv28Uuo5m2DZP');
+export const NONPROFIT_TEMPLATE = Id('HEuj9VYAF5z1KQ8x37Uzze');
+export const PERSON_TEMPLATE = Id('EJuFuEz17wdVCk9ctEAkW7');
+export const PROTOCOL_TEMPLATE = Id('UKKzBPkwY51qcVB9QTLNB6');
+export const REGION_TEMPLATE = Id('RL8uWpewpYdcmJ3rjoudjT');
 
-export const ONTOLOGY_PAGE_TEMPLATE = 'JjEDWDpLYS7tYBKi4vCdwc';
-export const EDUCATION_PAGE_TEMPLATE = 'RHuzjGkGothjuwGN6TLXDx';
-export const ABOUT_PAGE_TEMPLATE = '78qghJm6whF5proE9G93pX';
+export const ONTOLOGY_PAGE_TEMPLATE = Id('JjEDWDpLYS7tYBKi4vCdwc');
+export const EDUCATION_PAGE_TEMPLATE = Id('RHuzjGkGothjuwGN6TLXDx');
+export const ABOUT_PAGE_TEMPLATE = Id('78qghJm6whF5proE9G93pX');
 
 /**
  * Defines the type of the page being copied when creating an entity
  * from a template.
  */
-export const ABOUT_PAGE = 'Xn4sgn16Peoe64NSoARRv4';
-export const ACTIVITIES_PAGE = 'zfgeDtfzvmt9xbWVJj9DE';
-export const CULTURE_PAGE = 'EJuJfWHqXnorH4zbLgawC';
-export const EDUCATION_PAGE = 'Qh8AQ8hQhXiaAbe8HkgAJV';
-export const EVENTS_PAGE = 'K97FaTqrx54jdiM93vZ1Fc';
-export const FINANCES_PAGE = 'R6FDYEK9CCdEQuxjuRjA2U';
-export const GOVERNMENT_PAGE = 'AyQpCWpt4p58B4CFu6GYPJ';
-export const JOBS_PAGE = 'PJzxY3isAL3hGx1bRkYdPf';
-export const NEWS_PAGE = 'Ss6NVRoX8HKaEyFTEYNdUv';
-export const ONTOLOGY_PAGE = 'Ee2Es1b9PkfnR7nsbY2ubE';
-export const PEOPLE_PAGE = '5PatoErephYf1ZJ8U6rNz8';
-export const PERSONAL_PAGE = 'NPiVay5xbawmNJu7E1FLD';
-export const PLACES_PAGE = 'VAuhjqTMdZ2UR4Hj1TekTh';
-export const POSTS_PAGE = 'E3jboNrTeuopjKgJ45ykBd';
-export const PRODUCTS_PAGE = 'Cnf53HgY8T7Fwcq8choaRn';
-export const PROFESSIONAL_PAGE = 'RTdzv7qaBfjrSKbEnvCdaT';
-export const PROJECTS_PAGE = '3scJVFciFuhmaXe852pT3F';
-export const SERVICES_PAGE = '2V8pajmGDJt8egodkJeoPC';
-export const SPACES_PAGE = 'JAPV1HvzUBXH1advi47FWN';
-export const TEAM_PAGE = 'BWMHGbpR31xTbjvk4QZdQA';
+export const ABOUT_PAGE = Id('Xn4sgn16Peoe64NSoARRv4');
+export const ACTIVITIES_PAGE = Id('zfgeDtfzvmt9xbWVJj9DE');
+export const CULTURE_PAGE = Id('EJuJfWHqXnorH4zbLgawC');
+export const EDUCATION_PAGE = Id('Qh8AQ8hQhXiaAbe8HkgAJV');
+export const EVENTS_PAGE = Id('K97FaTqrx54jdiM93vZ1Fc');
+export const FINANCES_PAGE = Id('R6FDYEK9CCdEQuxjuRjA2U');
+export const GOVERNMENT_PAGE = Id('AyQpCWpt4p58B4CFu6GYPJ');
+export const JOBS_PAGE = Id('PJzxY3isAL3hGx1bRkYdPf');
+export const NEWS_PAGE = Id('Ss6NVRoX8HKaEyFTEYNdUv');
+export const ONTOLOGY_PAGE = Id('Ee2Es1b9PkfnR7nsbY2ubE');
+export const PEOPLE_PAGE = Id('5PatoErephYf1ZJ8U6rNz8');
+export const PERSONAL_PAGE = Id('NPiVay5xbawmNJu7E1FLD');
+export const PLACES_PAGE = Id('VAuhjqTMdZ2UR4Hj1TekTh');
+export const POSTS_PAGE = Id('E3jboNrTeuopjKgJ45ykBd');
+export const PRODUCTS_PAGE = Id('Cnf53HgY8T7Fwcq8choaRn');
+export const PROFESSIONAL_PAGE = Id('RTdzv7qaBfjrSKbEnvCdaT');
+export const PROJECTS_PAGE = Id('3scJVFciFuhmaXe852pT3F');
+export const SERVICES_PAGE = Id('2V8pajmGDJt8egodkJeoPC');
+export const SPACES_PAGE = Id('JAPV1HvzUBXH1advi47FWN');
+export const TEAM_PAGE = Id('BWMHGbpR31xTbjvk4QZdQA');
 
-export const FINANCE_OVERVIEW_TYPE = '5LHixDnR2vBTx26kmbnyih';
-export const FINANCE_SUMMMARY_TYPE = '8zrMWkTeDkfxbGn1U1MjLx';
+export const FINANCE_OVERVIEW_TYPE = Id('5LHixDnR2vBTx26kmbnyih');
+export const FINANCE_SUMMMARY_TYPE = Id('8zrMWkTeDkfxbGn1U1MjLx');
 
 /** Identity */
-export const ACCOUNT_TYPE = 'S7rX6suDMmU75yjbAD5WsP';
-export const ACCOUNTS_PROPERTY = 'VA5i7mm1v3QMjUChMT5dPs';
+export const ACCOUNT_TYPE = Id('S7rX6suDMmU75yjbAD5WsP');
+export const ACCOUNTS_PROPERTY = Id('VA5i7mm1v3QMjUChMT5dPs');
 /*
  * @deprecated use ACCOUNTS_PROPERTY
  */
-export const ACCOUNTS_ATTRIBUTE = 'VA5i7mm1v3QMjUChMT5dPs';
-export const ADDRESS_PROPERTY = 'HXLpAZyQkcy6Di4YJu4xzU';
+export const ACCOUNTS_ATTRIBUTE = Id('VA5i7mm1v3QMjUChMT5dPs');
+export const ADDRESS_PROPERTY = Id('HXLpAZyQkcy6Di4YJu4xzU');
 /*
  * @deprecated use ADDRESS_PROPERTY
  */
-export const ADDRESS_ATTRIBUTE = 'HXLpAZyQkcy6Di4YJu4xzU';
-export const NETWORK_PROPERTY = 'MuMLDVbHAmRjZQjhyk3HGx';
+export const ADDRESS_ATTRIBUTE = Id('HXLpAZyQkcy6Di4YJu4xzU');
+export const NETWORK_PROPERTY = Id('MuMLDVbHAmRjZQjhyk3HGx');
 /*
  * @deprecated use NETWORK_PROPERTY
  */
-export const NETWORK_ATTRIBUTE = 'MuMLDVbHAmRjZQjhyk3HGx';
-export const PERSON_TYPE = 'GfN9BK2oicLiBHrUavteS8';
-export const NETWORK_TYPE = 'YCLXoVZho6C4S51g4AbF3C';
+export const NETWORK_ATTRIBUTE = Id('MuMLDVbHAmRjZQjhyk3HGx');
+export const PERSON_TYPE = Id('GfN9BK2oicLiBHrUavteS8');
+export const NETWORK_TYPE = Id('YCLXoVZho6C4S51g4AbF3C');
 
-export const GOALS_PROPERTY = 'WNcdorfdj7ZprmwvmRiRtG';
+export const GOALS_PROPERTY = Id('WNcdorfdj7ZprmwvmRiRtG');
 /*
  * @deprecated use GOALS_PROPERTY
  */
-export const GOALS_ATTRIBUTE = 'WNcdorfdj7ZprmwvmRiRtG';
-export const GOAL_TYPE = '2y44qmFiLjZWmgkZ64EM7c';
-export const MEMBERSHIP_CONTRACT_ADDRESS = 'DDkwCoB8p1mHzXTedShcFv';
-export const MISSION_PROPERTY = 'VGbyCo12NC8yTUhnhMHu1z';
+export const GOALS_ATTRIBUTE = Id('WNcdorfdj7ZprmwvmRiRtG');
+export const GOAL_TYPE = Id('2y44qmFiLjZWmgkZ64EM7c');
+export const MEMBERSHIP_CONTRACT_ADDRESS = Id('DDkwCoB8p1mHzXTedShcFv');
+export const MISSION_PROPERTY = Id('VGbyCo12NC8yTUhnhMHu1z');
 /*
  * @deprecated use MISSION_PROPERTY
  */
-export const MISSION_ATTRIBUTE = 'VGbyCo12NC8yTUhnhMHu1z';
-export const PLACEHOLDER_IMAGE = 'ENYn2afpf2koqBfyff7CGE';
-export const PLACEHOLDER_TEXT = 'AuihGk1yXCkfCcpMSwhfho';
-export const TAB_TYPE = '6ym81VzJiHx32nV8e5h52q';
-export const ROLE_PROPERTY = 'VGKSRGzxCRvQxpJP7CB4wj';
+export const MISSION_ATTRIBUTE = Id('VGbyCo12NC8yTUhnhMHu1z');
+export const PLACEHOLDER_IMAGE = Id('ENYn2afpf2koqBfyff7CGE');
+export const PLACEHOLDER_TEXT = Id('AuihGk1yXCkfCcpMSwhfho');
+export const TAB_TYPE = Id('6ym81VzJiHx32nV8e5h52q');
+export const ROLE_PROPERTY = Id('VGKSRGzxCRvQxpJP7CB4wj');
 /*
  * @deprecated use ROLE_PROPERTY
  */
-export const ROLE_ATTRIBUTE = 'VGKSRGzxCRvQxpJP7CB4wj';
+export const ROLE_ATTRIBUTE = Id('VGKSRGzxCRvQxpJP7CB4wj');
 
 // Do we still need these?
-export const DEFAULT_TYPE = '7nJuuYkrKT62HCFxDygF1S';
-export const BROADER_CLAIMS_PROPERTY = 'RWkXuBRdVqDAiHKQisTZZ4';
+export const DEFAULT_TYPE = Id('7nJuuYkrKT62HCFxDygF1S');
+export const BROADER_CLAIMS_PROPERTY = Id('RWkXuBRdVqDAiHKQisTZZ4');
 /*
  * @deprecated use BROADER_CLAIMS_PROPERTY
  */
-export const BROADER_CLAIMS_ATTRIBUTE = 'RWkXuBRdVqDAiHKQisTZZ4';
-export const CLAIMS_FROM_PROPERTY = 'JdNBawSt1fp9EdozJdmThR';
+export const BROADER_CLAIMS_ATTRIBUTE = Id('RWkXuBRdVqDAiHKQisTZZ4');
+export const CLAIMS_FROM_PROPERTY = Id('JdNBawSt1fp9EdozJdmThR');
 /*
  * @deprecated use CLAIMS_FROM_PROPERTY
  */
-export const CLAIMS_FROM_ATTRIBUTE = 'JdNBawSt1fp9EdozJdmThR';
-export const DEFINITIONS_PROPERTY = '256myJaotY6FB6wGiC5mtk';
+export const CLAIMS_FROM_ATTRIBUTE = Id('JdNBawSt1fp9EdozJdmThR');
+export const DEFINITIONS_PROPERTY = Id('256myJaotY6FB6wGiC5mtk');
 /*
  * @deprecated use DEFINITIONS_PROPERTY
  */
-export const DEFINITIONS_ATTRIBUTE = '256myJaotY6FB6wGiC5mtk';
-export const EMAIL_PROPERTY = '2QafYRmRHP2Hd18W3Tj9zu';
+export const DEFINITIONS_ATTRIBUTE = Id('256myJaotY6FB6wGiC5mtk');
+export const EMAIL_PROPERTY = Id('2QafYRmRHP2Hd18W3Tj9zu');
 /*
  * @deprecated use EMAIL_PROPERTY
  */
-export const EMAIL_ATTRIBUTE = '2QafYRmRHP2Hd18W3Tj9zu';
-export const FOREIGN_TYPES = 'R32hqus9ojU3Twsz3HDuxf';
-export const NONPROFIT_CATEGORIES_PROPERTY = '64uVL5vKHmfqBC94hwNzHZ';
+export const EMAIL_ATTRIBUTE = Id('2QafYRmRHP2Hd18W3Tj9zu');
+export const FOREIGN_TYPES = Id('R32hqus9ojU3Twsz3HDuxf');
+export const NONPROFIT_CATEGORIES_PROPERTY = Id('64uVL5vKHmfqBC94hwNzHZ');
 /*
  * @deprecated use NONPROFIT_CATEGORIES_PROPERTY
  */
-export const NONPROFIT_CATEGORIES_ATTRIBUTE = '64uVL5vKHmfqBC94hwNzHZ';
-export const PHONE_NUMBER_PROPERTY = '3zhuyrcqFjeaVgC5oHHqTJ';
+export const NONPROFIT_CATEGORIES_ATTRIBUTE = Id('64uVL5vKHmfqBC94hwNzHZ');
+export const PHONE_NUMBER_PROPERTY = Id('3zhuyrcqFjeaVgC5oHHqTJ');
 /*
  * @deprecated use PHONE_NUMBER_PROPERTY
  */
-export const PHONE_NUMBER_ATTRIBUTE = '3zhuyrcqFjeaVgC5oHHqTJ';
-export const QUOTES_PROPERTY = 'XXAf2w4C5f4URDhhpH8nUG';
+export const PHONE_NUMBER_ATTRIBUTE = Id('3zhuyrcqFjeaVgC5oHHqTJ');
+export const QUOTES_PROPERTY = Id('XXAf2w4C5f4URDhhpH8nUG');
 /*
  * @deprecated use QUOTES_PROPERTY
  */
-export const QUOTES_ATTRIBUTE = 'XXAf2w4C5f4URDhhpH8nUG';
-export const REGION_PROPERTY = 'CGC6KXy8wcqf7vpZv8HH4i';
+export const QUOTES_ATTRIBUTE = Id('XXAf2w4C5f4URDhhpH8nUG');
+export const REGION_PROPERTY = Id('CGC6KXy8wcqf7vpZv8HH4i');
 /*
  * @deprecated use REGION_PROPERTY
  */
-export const REGION_ATTRIBUTE = 'CGC6KXy8wcqf7vpZv8HH4i';
-export const RELATED_TOPICS_PROPERTY = 'SDw38koZeFukda9FWU9bfW';
+export const REGION_ATTRIBUTE = Id('CGC6KXy8wcqf7vpZv8HH4i');
+export const RELATED_TOPICS_PROPERTY = Id('SDw38koZeFukda9FWU9bfW');
 /*
  * @deprecated use RELATED_TOPICS_PROPERTY
  */
-export const RELATED_TOPICS_ATTRIBUTE = 'SDw38koZeFukda9FWU9bfW';
-export const RELEVANT_QUESTIONS_PROPERTY = 'Po4uUtzinhjDwXJP5QNCMp';
+export const RELATED_TOPICS_ATTRIBUTE = Id('SDw38koZeFukda9FWU9bfW');
+export const RELEVANT_QUESTIONS_PROPERTY = Id('Po4uUtzinhjDwXJP5QNCMp');
 /*
  * @deprecated use RELEVANT_QUESTIONS_PROPERTY
  */
-export const RELEVANT_QUESTIONS_ATTRIBUTE = 'Po4uUtzinhjDwXJP5QNCMp';
-export const SPEAKERS_PROPERTY = '9nZuGhssmkEBn9DtRca8Gm';
+export const RELEVANT_QUESTIONS_ATTRIBUTE = Id('Po4uUtzinhjDwXJP5QNCMp');
+export const SPEAKERS_PROPERTY = Id('9nZuGhssmkEBn9DtRca8Gm');
 /*
  * @deprecated use SPEAKERS_PROPERTY
  */
-export const SPEAKERS_ATTRIBUTE = '9nZuGhssmkEBn9DtRca8Gm';
-export const STREET_ADDRESS_PROPERTY = '8kx7oQvdCZRXLfUksucwCv';
+export const SPEAKERS_ATTRIBUTE = Id('9nZuGhssmkEBn9DtRca8Gm');
+export const STREET_ADDRESS_PROPERTY = Id('8kx7oQvdCZRXLfUksucwCv');
 /*
  * @deprecated use STREET_ADDRESS_PROPERTY
  */
-export const STREET_ADDRESS_ATTRIBUTE = '8kx7oQvdCZRXLfUksucwCv';
-export const SUBCLAIMS_PROPERTY = '2DFyYPbh5Yy2PnWTbi3uL5';
+export const STREET_ADDRESS_ATTRIBUTE = Id('8kx7oQvdCZRXLfUksucwCv');
+export const SUBCLAIMS_PROPERTY = Id('2DFyYPbh5Yy2PnWTbi3uL5');
 /*
  * @deprecated use SUBCLAIMS_PROPERTY
  */
-export const SUBCLAIMS_ATTRIBUTE = '2DFyYPbh5Yy2PnWTbi3uL5';
-export const VALUES_PROPERTY = '3c5k2MpF9PRYAZ925qTKNi';
+export const SUBCLAIMS_ATTRIBUTE = Id('2DFyYPbh5Yy2PnWTbi3uL5');
+export const VALUES_PROPERTY = Id('3c5k2MpF9PRYAZ925qTKNi');
 /*
  * @deprecated use VALUES_PROPERTY
  */
-export const VALUES_ATTRIBUTE = '3c5k2MpF9PRYAZ925qTKNi';
-export const VISION_PROPERTY = 'AAMDNTaJtS2i4aWp59zEAk';
+export const VALUES_ATTRIBUTE = Id('3c5k2MpF9PRYAZ925qTKNi');
+export const VISION_PROPERTY = Id('AAMDNTaJtS2i4aWp59zEAk');
 /*
  * @deprecated use VISION_PROPERTY
  */
-export const VISION_ATTRIBUTE = 'AAMDNTaJtS2i4aWp59zEAk';
+export const VISION_ATTRIBUTE = Id('AAMDNTaJtS2i4aWp59zEAk');
 
-export const ROOT_SPACE_ID = '25omwWh6HYgeRQKCaSpVpa';
+export const ROOT_SPACE_ID = Id('25omwWh6HYgeRQKCaSpVpa');

--- a/src/graph/create-entity.test.ts
+++ b/src/graph/create-entity.test.ts
@@ -8,10 +8,15 @@ import {
   WEB_URL_PROPERTY,
 } from '../core/ids/content.js';
 import { NAME_PROPERTY, TYPES_PROPERTY } from '../core/ids/system.js';
-import { generate } from '../id.js';
+import { Id, generate } from '../id.js';
 import { createEntity } from './create-entity.js';
 
 describe('createEntity', () => {
+  const someAuthorId = Id('M5uDP7nCw3nvfQPUryn9gx');
+  const someRoleId = Id('GscJ2GELQjmLoaVrYyR3xm');
+  const someRoleId2 = Id('VdTsW1mGiy1XSooJaBBLc4');
+  const coverId = Id('6wMJ7P1AHpu8EWFX3roMye');
+
   it('creates a basic entity without properties', async () => {
     const entity = createEntity({});
     expect(entity).toBeDefined();
@@ -111,8 +116,8 @@ describe('createEntity', () => {
   it('creates an entity with relations', async () => {
     const entity = createEntity({
       properties: {
-        [AUTHORS_PROPERTY]: { to: 'some-author-id' },
-        [ROLES_PROPERTY]: [{ to: 'some-role-id' }, { to: 'some-role-id-2' }],
+        [AUTHORS_PROPERTY]: { to: someAuthorId },
+        [ROLES_PROPERTY]: [{ to: someRoleId }, { to: someRoleId2 }],
       },
     });
 
@@ -128,7 +133,7 @@ describe('createEntity', () => {
           fromEntity: entity.id,
           id: entity.ops[0]?.relation?.id,
           index: entity.ops[0]?.relation?.index,
-          toEntity: 'some-author-id',
+          toEntity: someAuthorId,
           type: AUTHORS_PROPERTY,
         },
         type: 'CREATE_RELATION',
@@ -142,7 +147,7 @@ describe('createEntity', () => {
           fromEntity: entity.id,
           id: entity.ops[1]?.relation?.id,
           index: entity.ops[1]?.relation?.index,
-          toEntity: 'some-role-id',
+          toEntity: someRoleId,
           type: ROLES_PROPERTY,
         },
         type: 'CREATE_RELATION',
@@ -156,7 +161,7 @@ describe('createEntity', () => {
           fromEntity: entity.id,
           id: entity.ops[2]?.relation?.id,
           index: entity.ops[2]?.relation?.index,
-          toEntity: 'some-role-id-2',
+          toEntity: someRoleId2,
           type: ROLES_PROPERTY,
         },
         type: 'CREATE_RELATION',
@@ -169,8 +174,8 @@ describe('createEntity', () => {
     const firstRoleRelationId = generate();
     const entity = createEntity({
       properties: {
-        [AUTHORS_PROPERTY]: { to: 'some-author-id', relationId: authorRelationId },
-        [ROLES_PROPERTY]: [{ to: 'some-role-id', relationId: firstRoleRelationId }, { to: 'some-role-id-2' }],
+        [AUTHORS_PROPERTY]: { to: someAuthorId, relationId: authorRelationId },
+        [ROLES_PROPERTY]: [{ to: someRoleId, relationId: firstRoleRelationId }, { to: someRoleId2 }],
       },
     });
 
@@ -181,7 +186,7 @@ describe('createEntity', () => {
           fromEntity: entity.id,
           id: authorRelationId,
           index: entity.ops[0]?.relation?.index,
-          toEntity: 'some-author-id',
+          toEntity: someAuthorId,
           type: AUTHORS_PROPERTY,
         },
         type: 'CREATE_RELATION',
@@ -195,7 +200,7 @@ describe('createEntity', () => {
           fromEntity: entity.id,
           id: firstRoleRelationId,
           index: entity.ops[1]?.relation?.index,
-          toEntity: 'some-role-id',
+          toEntity: someRoleId,
           type: ROLES_PROPERTY,
         },
         type: 'CREATE_RELATION',
@@ -210,15 +215,15 @@ describe('createEntity', () => {
     const entity = createEntity({
       properties: {
         [AUTHORS_PROPERTY]: {
-          to: 'some-author-id',
+          to: someAuthorId,
           relationId: authorRelationId,
           properties: {
             [ROLES_PROPERTY]: {
-              to: 'some-role-id',
+              to: someRoleId,
               relationId: roleRelationId,
               properties: {
                 [NEWS_STORY_TYPE]: {
-                  to: 'some-role-id-2',
+                  to: someRoleId2,
                   relationId: newsStoryRelationId,
                 },
                 [WEB_URL_PROPERTY]: {
@@ -239,7 +244,7 @@ describe('createEntity', () => {
           fromEntity: entity.id,
           id: authorRelationId,
           index: entity.ops[0]?.relation?.index,
-          toEntity: 'some-author-id',
+          toEntity: someAuthorId,
           type: AUTHORS_PROPERTY,
         },
         type: 'CREATE_RELATION',
@@ -253,7 +258,7 @@ describe('createEntity', () => {
           fromEntity: entity.id,
           id: roleRelationId,
           index: entity.ops[1]?.relation?.index,
-          toEntity: 'some-role-id',
+          toEntity: someRoleId,
           type: ROLES_PROPERTY,
         },
         type: 'CREATE_RELATION',
@@ -267,7 +272,7 @@ describe('createEntity', () => {
           fromEntity: entity.id,
           id: newsStoryRelationId,
           index: entity.ops[2]?.relation?.index,
-          toEntity: 'some-role-id-2',
+          toEntity: someRoleId2,
           type: NEWS_STORY_TYPE,
         },
         type: 'CREATE_RELATION',
@@ -291,13 +296,13 @@ describe('createEntity', () => {
     const entity = createEntity({
       name: 'Yummy Coffee',
       description: 'A delicious coffee shop with great food and great coffee',
-      cover: 'image-id',
+      cover: coverId,
       types: [CLAIM_TYPE, NEWS_STORY_TYPE],
       properties: {
         [DISCLAIMER_PROPERTY]: { value: 'Test Entity', type: 'TEXT' },
         [WEB_URL_PROPERTY]: { value: 'https://example.com', type: 'URL' },
-        [AUTHORS_PROPERTY]: { to: 'some-author-id' },
-        [ROLES_PROPERTY]: { to: 'some-role-id' },
+        [AUTHORS_PROPERTY]: { to: someAuthorId },
+        [ROLES_PROPERTY]: { to: someRoleId },
       },
     });
 

--- a/src/graph/create-entity.ts
+++ b/src/graph/create-entity.ts
@@ -1,5 +1,5 @@
 import { TYPES_PROPERTY } from '../core/ids/system.js';
-import { generate } from '../id.js';
+import { assertValid, generate } from '../id.js';
 import { Relation } from '../relation.js';
 import type { DefaultProperties, Op, PropertiesParam } from '../types.js';
 import { createDefaultProperties } from './helpers/create-default-properties.js';
@@ -21,6 +21,7 @@ export const createEntity = ({ name, description, cover, properties, types }: Pa
   // add property "Types" to the provided types
   if (types) {
     for (const typeId of types) {
+      assertValid(typeId);
       const typeRelationOp = Relation.make({
         fromId: id,
         relationTypeId: TYPES_PROPERTY,

--- a/src/graph/create-entity.ts
+++ b/src/graph/create-entity.ts
@@ -1,18 +1,55 @@
 import { TYPES_PROPERTY } from '../core/ids/system.js';
 import { assertValid, generate } from '../id.js';
 import { Relation } from '../relation.js';
-import type { DefaultProperties, Op, PropertiesParam } from '../types.js';
+import type { CreateResult, DefaultProperties, Op, PropertiesParam } from '../types.js';
 import { createDefaultProperties } from './helpers/create-default-properties.js';
 import { createProperties } from './helpers/create-properties.js';
-type Params = DefaultProperties & {
+type CreateEntityParams = DefaultProperties & {
   properties?: PropertiesParam;
   types?: Array<string>;
 };
 
 /**
  * Creates an entity with the given name, description, cover, properties, and types.
+ * All IDs passed to this function (cover, types, property IDs, relation IDs, etc.) are validated.
+ * If any invalid ID is provided, the function will throw an error.
+ *
+ * @example
+ * ```ts
+ * const { id, ops } = createEntity({
+ *   name: 'name of the entity',
+ *   description: 'description of the entity',
+ *   cover: imageEntityId,
+ *   types: [typeEntityId1, typeEntityId2],
+ *   properties: {
+ *     // value property like text, number, url, time, point, checkbox
+ *     [propertyId]: {
+ *       type: 'TEXT', // TEXT | NUMBER | URL | TIME | POINT | CHECKBOX,
+ *       value: 'value of the property',
+ *     },
+ *     // relation property
+ *     [propertyId]: {
+ *       to: 'id of the entity',
+ *       relationId: 'id of the relation', // optional
+ *       position: positionString, // optional
+ *       properties: { // optional properties for the relation
+ *         [propertyId]: {
+ *           type: 'TEXT', // TEXT | NUMBER | URL | TIME | POINT | CHECKBOX,
+ *           value: 'value of the property',
+ *         },
+ *         [propertyId]: {
+ *           to: 'id of the entity',
+ *         },
+ *       },
+ *     },
+ *   },
+ * });
+ * ```
+ * @param params – {@link CreateEntityParams}
+ * @returns – {@link CreateResult}
+ * @throws Will throw an error if any provided ID is invalid
  */
-export const createEntity = ({ name, description, cover, properties, types }: Params) => {
+export const createEntity = ({ name, description, cover, properties, types }: CreateEntityParams): CreateResult => {
   const id = generate();
   const ops: Array<Op> = [];
 

--- a/src/graph/create-property.ts
+++ b/src/graph/create-property.ts
@@ -12,7 +12,7 @@ import {
   URL,
   VALUE_TYPE_PROPERTY,
 } from '../core/ids/system.js';
-import { generate } from '../id.js';
+import { assertValid, generate } from '../id.js';
 import { Relation } from '../relation.js';
 import type { DefaultProperties, Op, ValueType } from '../types.js';
 import { createDefaultProperties } from './helpers/create-default-properties.js';
@@ -57,6 +57,7 @@ export const createProperty = (params: Params) => {
     // add the provided properties to property "Properties"
     if (params.properties) {
       for (const propertyId of params.properties) {
+        assertValid(propertyId);
         const relationOp = Relation.make({
           fromId: entityId,
           relationTypeId: PROPERTY,
@@ -68,6 +69,7 @@ export const createProperty = (params: Params) => {
     if (params.relationValueTypes) {
       // add the provided relation value types to property "Relation Value Types"
       for (const relationValueTypeId of params.relationValueTypes) {
+        assertValid(relationValueTypeId);
         const relationOp = Relation.make({
           fromId: entityId,
           relationTypeId: RELATION_VALUE_RELATIONSHIP_TYPE,

--- a/src/graph/create-property.ts
+++ b/src/graph/create-property.ts
@@ -14,16 +14,31 @@ import {
 } from '../core/ids/system.js';
 import { assertValid, generate } from '../id.js';
 import { Relation } from '../relation.js';
-import type { DefaultProperties, Op, ValueType } from '../types.js';
+import type { CreateResult, DefaultProperties, Op, ValueType } from '../types.js';
 import { createDefaultProperties } from './helpers/create-default-properties.js';
 
-type Params = DefaultProperties &
+type CreatePropertyParams = DefaultProperties &
   ({ type: ValueType } | { type: 'RELATION'; properties?: Array<string>; relationValueTypes?: Array<string> });
 
 /**
  * Creates a property with the given name, description, cover, and type.
+ * All IDs passed to this function (cover, relation value types) are validated.
+ * If any invalid ID is provided, the function will throw an error.
+ *
+ * @example
+ * ```ts
+ * const { id, ops } = createProperty({
+ *   name: 'name of the property',
+ *   type: 'TEXT'
+ *   description: 'description of the property',
+ *   cover: imageEntityId,
+ * });
+ * ```
+ * @param params – {@link CreatePropertyParams}
+ * @returns – {@link CreateResult}
+ * @throws Will throw an error if any provided ID is invalid
  */
-export const createProperty = (params: Params) => {
+export const createProperty = (params: CreatePropertyParams): CreateResult => {
   const { name, description, cover } = params;
   const entityId = generate();
   const ops: Op[] = [];

--- a/src/graph/create-type.ts
+++ b/src/graph/create-type.ts
@@ -1,16 +1,31 @@
 import { PROPERTY, SCHEMA_TYPE, TYPES_PROPERTY } from '../core/ids/system.js';
 import { type Id, assertValid, generate } from '../id.js';
 import { Relation } from '../relation.js';
-import type { CreateRelationOp, DefaultProperties, Op } from '../types.js';
+import type { CreateRelationOp, CreateResult, DefaultProperties, Op } from '../types.js';
 import { createDefaultProperties } from './helpers/create-default-properties.js';
-type Params = DefaultProperties & {
+type CreateTypeParams = DefaultProperties & {
   properties?: Array<Id>;
 };
 
 /**
  * Creates a type with the given name, description, cover, and properties.
+ * All IDs passed to this function (cover, property IDs) are validated.
+ * If any invalid ID is provided, the function will throw an error.
+ *
+ * @example
+ * ```ts
+ * const { id, ops } = createType({
+ *   name: 'name of the type',
+ *   description: 'description of the type',
+ *   cover: imageEntityId,
+ *   properties: [propertyEntityId1, propertyEntityId2],
+ * });
+ * ```
+ * @param params – {@link CreateTypeParams}
+ * @returns – {@link CreateResult}
+ * @throws Will throw an error if any provided ID is invalid
  */
-export const createType = ({ name, description, cover, properties }: Params) => {
+export const createType = ({ name, description, cover, properties }: CreateTypeParams): CreateResult => {
   const id = generate();
   const ops: Op[] = [];
 

--- a/src/graph/create-type.ts
+++ b/src/graph/create-type.ts
@@ -1,10 +1,10 @@
 import { PROPERTY, SCHEMA_TYPE, TYPES_PROPERTY } from '../core/ids/system.js';
-import { generate } from '../id.js';
+import { type Id, assertValid, generate } from '../id.js';
 import { Relation } from '../relation.js';
 import type { CreateRelationOp, DefaultProperties, Op } from '../types.js';
 import { createDefaultProperties } from './helpers/create-default-properties.js';
 type Params = DefaultProperties & {
-  properties?: Array<string>;
+  properties?: Array<Id>;
 };
 
 /**
@@ -17,6 +17,7 @@ export const createType = ({ name, description, cover, properties }: Params) => 
   ops.push(...createDefaultProperties({ entityId: id, name, description, cover }));
 
   // set property "Types" to "Type"
+  assertValid(id);
   const relationOp = Relation.make({
     fromId: id,
     relationTypeId: TYPES_PROPERTY,
@@ -26,6 +27,7 @@ export const createType = ({ name, description, cover, properties }: Params) => 
 
   if (properties) {
     for (const propertyId of properties) {
+      assertValid(propertyId);
       const relationOp: CreateRelationOp = Relation.make({
         fromId: id,
         relationTypeId: PROPERTY,

--- a/src/graph/helpers/create-default-properties.ts
+++ b/src/graph/helpers/create-default-properties.ts
@@ -1,4 +1,5 @@
 import { COVER_PROPERTY, DESCRIPTION_PROPERTY, NAME_PROPERTY } from '../../core/ids/system.js';
+import { assertValid } from '../../id.js';
 import { Relation } from '../../relation.js';
 import { Triple } from '../../triple.js';
 import type { DefaultProperties, Op } from '../../types.js';
@@ -35,6 +36,7 @@ export const createDefaultProperties = (params: DefaultProperties & { entityId: 
 
   if (cover) {
     // add ID of cover "Image" to property "Cover"
+    assertValid(cover);
     const relationOp = Relation.make({
       fromId: entityId,
       relationTypeId: COVER_PROPERTY,

--- a/src/graph/helpers/create-properties.ts
+++ b/src/graph/helpers/create-properties.ts
@@ -1,8 +1,7 @@
-import { generate } from '../../id.js';
+import { assertValid, generate } from '../../id.js';
 import { Relation } from '../../relation.js';
 import { Triple } from '../../triple.js';
-import type { PropertiesParam } from '../../types.js';
-import type { Op } from '../../types.js';
+import type { Op, PropertiesParam } from '../../types.js';
 
 type CreatePropertiesParams = {
   entityId: string;
@@ -14,6 +13,7 @@ export const createProperties = (params: CreatePropertiesParams) => {
   const ops: Op[] = [];
 
   for (const [attributeId, property] of Object.entries(properties)) {
+    assertValid(attributeId);
     if ('type' in property) {
       const propertyTripleOp = Triple.make({
         entityId,
@@ -23,6 +23,8 @@ export const createProperties = (params: CreatePropertiesParams) => {
       ops.push(propertyTripleOp);
     } else if ('to' in property) {
       const relationId = property.relationId ?? generate();
+      assertValid(relationId);
+      assertValid(property.to);
       const propertyRelationOp = Relation.make({
         relationId,
         fromId: entityId,
@@ -37,6 +39,8 @@ export const createProperties = (params: CreatePropertiesParams) => {
     } else if (Array.isArray(property)) {
       for (const relation of property) {
         const relationId = relation.relationId ?? generate();
+        assertValid(relationId);
+        assertValid(relation.to);
         const propertyRelationOp = Relation.make({
           relationId,
           fromId: entityId,

--- a/src/id.test.ts
+++ b/src/id.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest';
 
 import { BASE58_ALLOWED_CHARS } from './core/base58.js';
-import { generate } from './id.js';
+import { generate, isValid } from './id.js';
 
 // @NOTE this would be a good candidate for DST-style tests
 it('should generate valid base58 encoded id with length of 22', () => {
@@ -9,4 +9,15 @@ it('should generate valid base58 encoded id with length of 22', () => {
   expect(id).toBeTypeOf('string');
   expect(id.length).toBe(22);
   expect(id.split('').every(char => BASE58_ALLOWED_CHARS.includes(char))).toBe(true);
+});
+
+it('should validate base58 encoded id', () => {
+  expect(isValid(generate())).toBe(true);
+  expect(isValid(generate())).toBe(true);
+  expect(isValid(generate())).toBe(true);
+});
+
+it('should not validate invalid id', () => {
+  expect(isValid('invalid-id')).toBe(false);
+  expect(isValid('0123456789012345678901')).toBe(false);
 });

--- a/src/id.test.ts
+++ b/src/id.test.ts
@@ -15,6 +15,9 @@ it('should validate base58 encoded id', () => {
   expect(isValid(generate())).toBe(true);
   expect(isValid(generate())).toBe(true);
   expect(isValid(generate())).toBe(true);
+  expect(isValid('M5uDP7nCw3nvfQPUryn9gx')).toBe(true);
+  // length is 21
+  expect(isValid('D6Wy4bdtdoUrG3PDZceHr')).toBe(true);
 });
 
 it('should not validate invalid id', () => {

--- a/src/id.ts
+++ b/src/id.ts
@@ -34,22 +34,22 @@ export const Id = Brand.refined<Id>(
 export function generate(): Id {
   const uuid = uuidv4();
   const stripped = uuid.replaceAll(/-/g, '');
-  const id = Id(encodeBase58(stripped));
+  const rawId = encodeBase58(stripped);
 
   // In extremely rare occasions the id generator may result in ids that are
   // 21 characters instead of 22. Theoretically the smallest length the id can
   // generate is 16 characters, but only in specifically engineered cases.
   //
   // If this occurs we can generate again until we get a valid id.
-  if (id.length === 22) {
-    return id;
+  if (rawId.length === 22) {
+    return Id(rawId);
   }
 
   return generate();
 }
 
 export function isValid(id: string): boolean {
-  if (id.length !== 22 && id.length !== 21) {
+  if (id.length !== 22) {
     return false;
   }
 

--- a/src/id.ts
+++ b/src/id.ts
@@ -49,7 +49,7 @@ export function generate(): Id {
 }
 
 export function isValid(id: string): boolean {
-  if (id.length !== 22) {
+  if (id.length !== 22 && id.length !== 21) {
     return false;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Id } from './id.js';
+
 type OmitStrict<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export type ValueType = 'TEXT' | 'NUMBER' | 'CHECKBOX' | 'URL' | 'TIME' | 'POINT';
@@ -120,7 +122,7 @@ export type GraphUri = `graph://${string}`;
 export type DefaultProperties = {
   name?: string;
   description?: string;
-  cover?: string;
+  cover?: Id;
 };
 
 type ValueParams = {
@@ -129,8 +131,8 @@ type ValueParams = {
 };
 
 type RelationParams = {
-  to: string;
-  relationId?: string;
+  to: Id;
+  relationId?: Id;
   position?: string;
   properties?: Record<string, ValueParams | RelationParams | Array<RelationParams>>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,3 +138,8 @@ type RelationParams = {
 };
 
 export type PropertiesParam = Record<string, ValueParams | RelationParams | Array<RelationParams>>;
+
+export type CreateResult = {
+  id: Id;
+  ops: Op[];
+};


### PR DESCRIPTION
- Add branded type `Id` with refined that validates the ID. see https://effect.website/docs/code-style/branded-types/#refined
- Add dynamic validation for all `Graph` functions
- Changed the following system IDs (since they were invalid e.g. length of 21):
  - `QUOTES_THAT_SUPPORT_CLAIMS_PROPERTY ` from `quotesThatSupportClaims` to `WoWTti3qGM1nvz28K9zu1f`
  - `ACADEMIC_FIELD_TYPE` from `ExCjm3rzYVfpMRwDchdrE ` to `KwKGhkY5AmzmHHggg7abvi`