### PR TITLE
feat: add createImage

### DIFF
--- a/.changeset/fifty-squids-study.md
+++ b/.changeset/fifty-squids-study.md
@@ -1,0 +1,5 @@
+---
+"@graphprotocol/grc-20": patch
+---
+
+add createImage to Graph namespace

--- a/README.md
+++ b/README.md
@@ -113,10 +113,18 @@ const { id: personTypeId, ops: createPersonTypeOps } = Graph.createType({
   properties: […listOfPropertyIds],
 });
 
+// create an image
+const { id: imageId, ops: createImageOps } = await Graph.createImage({
+  url: 'https://example.com/image.png',
+  // blob: new Blob([fs.readFileSync(path.join(__dirname, 'cover.png'))], { type: 'image/png' });
+});
+
 // create an entity
 const { id: restaurantId, ops: createRestaurantOps } = Graph.createEntity({
   name: 'name of the entity',
+  description: 'description of the entity',
   types: […listOfTypeIds],
+  cover: imageId,
   properties: {
     // value property like text, number, url, time, point, checkbox
     [propertyId]: {
@@ -163,15 +171,23 @@ ops.push(...createLikesPropertyOps);
 // create a person type
 const { id: personTypeId, ops: createPersonTypeOps } = Graph.createType({
   name: 'Person',
+  cover: personCoverId,
   properties: [agePropertyId, likesPropertyId],
 });
 ops.push(...createPersonTypeOps);
+
+// create an restaurant cover image
+const { id: restaurantCoverId, ops: createRestaurantCoverOps } = await Graph.createImage({
+  url: 'https://example.com/image.png',
+});
+ops.push(...createRestaurantCoverOps);
 
 // create a restaurant entity with a website property
 const restaurantTypeId = 'A9QizqoXSqjfPUBjLoPJa2';
 const { id: restaurantId, ops: createRestaurantOps } = Graph.createEntity({
   name: 'Yum Yum',
   description: 'A restaurant serving fusion cuisine',
+  cover: restaurantCoverId,
   types: [restaurantTypeId],
   properties: {
     [WEBSITE_PROPERTY]: {
@@ -182,10 +198,17 @@ const { id: restaurantId, ops: createRestaurantOps } = Graph.createEntity({
 });
 ops.push(...createRestaurantOps);
 
+// create a person cover image
+const { id: personCoverId, ops: createPersonCoverOps } = await Graph.createImage({
+  url: 'https://example.com/avatar.png',
+});
+ops.push(...createPersonCoverOps);
+
 // create a person entity with a likes relation to the restaurant entity
 const { id: personId, ops: createPersonOps } = Graph.createEntity({
   name: 'Jane Doe',
   types: [personTypeId],
+  cover: personCoverId,
   properties: {
     [agePropertyId]: {
       type: 'NUMBER',

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@ethersproject/providers": "^5.6.8",
     "effect": "^3.12.11",
     "ethers": "^5.7.2",
+    "image-size": "^2.0.0",
     "position-strings": "^2.0.1",
     "uuid": "^11.1.0",
     "viem": "^1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
+      image-size:
+        specifier: ^2.0.0
+        version: 2.0.0
       position-strings:
         specifier: ^2.0.1
         version: 2.0.1
@@ -859,6 +862,11 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  image-size@2.0.0:
+    resolution: {integrity: sha512-HP07n1SpdIXGUL4VotUIOQz66MQOq8g7VN+Yj02YTVowqZScQ5i/JYU0+lkNr2pwt5j4hOpk94/UBV1ZCbS2fA==}
+    engines: {node: '>=16.x'}
+    hasBin: true
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2292,6 +2300,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
+
+  image-size@2.0.0: {}
 
   inherits@2.0.4: {}
 

--- a/src/core/image.test.ts
+++ b/src/core/image.test.ts
@@ -4,25 +4,53 @@ import { SystemIds } from '../system-ids.js';
 import { make } from './image.js';
 
 it('should generate ops for an image entity', () => {
-  const { imageId, ops } = make('https://example.com/image.png');
-  const [createRelationOp, setTripleOp] = ops;
+  const { id, ops } = make({ cid: 'https://example.com/image.png' });
 
   // We check each field individually since we don't know the id of the relation
-  expect(createRelationOp.type).toEqual('CREATE_RELATION');
-  expect(createRelationOp.relation.type).toBe(SystemIds.TYPES_PROPERTY);
-  expect(createRelationOp.relation.fromEntity).toBe(imageId);
-  expect(createRelationOp.relation.toEntity).toBe(SystemIds.IMAGE_TYPE);
-  expect(createRelationOp.relation.index).toBe(INITIAL_RELATION_INDEX_VALUE);
+  expect(typeof id).toBe('string');
+  expect(ops.length).toBe(2);
+  if (ops[0]?.type === 'CREATE_RELATION') {
+    expect(ops[0].relation.type).toBe(SystemIds.TYPES_PROPERTY);
+    expect(ops[0].relation.fromEntity).toBe(id);
+    expect(ops[0].relation.toEntity).toBe(SystemIds.IMAGE_TYPE);
+    expect(ops[0].relation.index).toBe(INITIAL_RELATION_INDEX_VALUE);
+  }
 
-  expect(setTripleOp).toEqual({
-    type: 'SET_TRIPLE',
-    triple: {
-      attribute: SystemIds.IMAGE_URL_PROPERTY,
-      entity: imageId,
-      value: {
-        type: 'URL',
-        value: 'https://example.com/image.png',
-      },
-    },
-  });
+  if (ops[1]?.type === 'SET_TRIPLE') {
+    expect(ops[1].triple.attribute).toBe(SystemIds.IMAGE_URL_PROPERTY);
+    expect(ops[1].triple.entity).toBe(id);
+    expect(ops[1].triple.value.type).toBe('URL');
+    expect(ops[1].triple.value.value).toBe('https://example.com/image.png');
+  }
+});
+
+it('should generate ops for an image entity with dimensions', () => {
+  const { id, ops } = make({ cid: 'https://example.com/image.png', dimensions: { width: 200, height: 100 } });
+
+  expect(typeof id).toBe('string');
+  expect(ops.length).toBe(4);
+  if (ops[0]?.type === 'CREATE_RELATION') {
+    expect(ops[0].relation.type).toBe(SystemIds.TYPES_PROPERTY);
+    expect(ops[0].relation.fromEntity).toBe(id);
+    expect(ops[0].relation.toEntity).toBe(SystemIds.IMAGE_TYPE);
+    expect(ops[0].relation.index).toBe(INITIAL_RELATION_INDEX_VALUE);
+  }
+  if (ops[1]?.type === 'SET_TRIPLE') {
+    expect(ops[1].triple.attribute).toBe(SystemIds.IMAGE_URL_PROPERTY);
+    expect(ops[1].triple.entity).toBe(id);
+    expect(ops[1].triple.value.type).toBe('URL');
+    expect(ops[1].triple.value.value).toBe('https://example.com/image.png');
+  }
+  if (ops[2]?.type === 'SET_TRIPLE') {
+    expect(ops[2].triple.attribute).toBe(SystemIds.IMAGE_HEIGHT_PROPERTY);
+    expect(ops[2].triple.entity).toBe(id);
+    expect(ops[2].triple.value.type).toBe('NUMBER');
+    expect(ops[2].triple.value.value).toBe('100');
+  }
+  if (ops[3]?.type === 'SET_TRIPLE') {
+    expect(ops[3].triple.attribute).toBe(SystemIds.IMAGE_WIDTH_PROPERTY);
+    expect(ops[3].triple.entity).toBe(id);
+    expect(ops[3].triple.value.type).toBe('NUMBER');
+    expect(ops[3].triple.value.value).toBe('200');
+  }
 });

--- a/src/core/image.ts
+++ b/src/core/image.ts
@@ -5,14 +5,22 @@
  * @since 0.0.6
  */
 
-import { generate } from '../id.js';
+import { type Id, generate } from '../id.js';
 import { Relation } from '../relation.js';
 import { SystemIds } from '../system-ids.js';
-import type { CreateRelationOp, SetTripleOp } from '../types.js';
+import type { Op } from '../types.js';
 
 type MakeImageReturnType = {
-  imageId: string;
-  ops: [CreateRelationOp, SetTripleOp];
+  id: Id;
+  ops: Array<Op>;
+};
+
+type MakeImageParams = {
+  cid: string;
+  dimensions?: {
+    width: number;
+    height: number;
+  };
 };
 
 /**
@@ -20,36 +28,62 @@ type MakeImageReturnType = {
  *
  * @example
  * ```ts
- * const { imageId, ops } = Image.make('https://example.com/image.png');
- * console.log(imageId); // 'gw9uTVTnJdhtczyuzBkL3X'
+ * const { id, ops } = Image.make({ cid: 'https://example.com/image.png', dimensions: { width: 100, height: 100 } });
+ * console.log(id); // 'gw9uTVTnJdhtczyuzBkL3X'
  * console.log(ops); // [...]
  * ```
  *
- * @returns imageId – base58 encoded v4 uuid representing the image entity: {@link MakeImageReturnType}
+ * @returns id – base58 encoded v4 uuid representing the image entity: {@link MakeImageReturnType}
  * @returns ops – The ops for the Image entity: {@link MakeImageReturnType}
  */
-export function make(src: string): MakeImageReturnType {
+export function make({ cid, dimensions }: MakeImageParams): MakeImageReturnType {
   const entityId = generate();
-
-  return {
-    imageId: entityId,
-    ops: [
-      Relation.make({
-        fromId: entityId,
-        toId: SystemIds.IMAGE_TYPE,
-        relationTypeId: SystemIds.TYPES_PROPERTY,
-      }),
-      {
-        type: 'SET_TRIPLE',
-        triple: {
-          entity: entityId,
-          attribute: SystemIds.IMAGE_URL_PROPERTY,
-          value: {
-            type: 'URL',
-            value: src,
-          },
+  const ops: Array<Op> = [
+    Relation.make({
+      fromId: entityId,
+      toId: SystemIds.IMAGE_TYPE,
+      relationTypeId: SystemIds.TYPES_PROPERTY,
+    }),
+    {
+      type: 'SET_TRIPLE',
+      triple: {
+        entity: entityId,
+        attribute: SystemIds.IMAGE_URL_PROPERTY,
+        value: {
+          type: 'URL',
+          value: cid,
         },
       },
-    ],
+    },
+  ];
+
+  if (dimensions) {
+    ops.push({
+      type: 'SET_TRIPLE',
+      triple: {
+        entity: entityId,
+        attribute: SystemIds.IMAGE_HEIGHT_PROPERTY,
+        value: {
+          type: 'NUMBER',
+          value: dimensions.height.toString(),
+        },
+      },
+    });
+    ops.push({
+      type: 'SET_TRIPLE',
+      triple: {
+        entity: entityId,
+        attribute: SystemIds.IMAGE_WIDTH_PROPERTY,
+        value: {
+          type: 'NUMBER',
+          value: dimensions.width.toString(),
+        },
+      },
+    });
+  }
+
+  return {
+    id: entityId,
+    ops,
   };
 }

--- a/src/graph/create-image.test.ts
+++ b/src/graph/create-image.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SystemIds } from '../system-ids.js';
+import { createImage } from './create-image.js';
+
+// serialized like this:
+// const buffer = Buffer.from(await blob.arrayBuffer());
+// const base64 = buffer.toString('base64');
+// console.log('base64', base64);
+const testImageContent =
+  'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAHCAMAAAAGcixRAAAAY1BMVEXvvubYz97i2Ojm3Oz4vu3gv+f2yfTqxvDj1v/hxe/u0Pvn1v3Oxc7wx/LHs87r2uzYs7np3++lnaPq1OrZxtjx3PL8xPLG0OXjyuHizeS3qsDfz+nMu8PZtc3TvNjdyO77z/t7oOngAAAACnRSTlP+////y/7e/tbEPoYQ1AAAAAlwSFlzAAALEwAACxMBAJqcGAAAAEhJREFUeNoFwQkCQDAMBMBNgtJL77r5/yvNYPqc1toYM+Pt1VPcgjDGvj4ke2BGS3Y9SSQRUDh7kkKM+5J82OptxNAA55TSyw+IpgNhAhO+gAAAAABJRU5ErkJggg==';
+
+const testImageBlob = new Blob([Buffer.from(testImageContent, 'base64')], { type: 'image/png' });
+const ipfsUploadUrl = 'https://api-testnet.grc-20.thegraph.com/ipfs/upload-file';
+
+describe('createImage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(global, 'fetch').mockImplementation(url => {
+      if (url.toString() === 'http://localhost:3000/image') {
+        return Promise.resolve({
+          status: 200,
+          blob: () => Promise.resolve(testImageBlob),
+        } as Response);
+      }
+      if (url.toString() === ipfsUploadUrl) {
+        return Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve({ cid: 'ipfs://bafkreidgcqofpstvkzylgxbcn4xan6camlgf564sasepyt45sjgvnojxp4' }),
+        } as Response);
+      }
+      return vi.fn() as never;
+    });
+  });
+
+  it('creates an image from a url', async () => {
+    const image = await createImage({
+      url: 'http://localhost:3000/image',
+    });
+
+    expect(image).toBeDefined();
+    expect(typeof image.id).toBe('string');
+    expect(image.ops).toBeDefined();
+    expect(image.ops).toHaveLength(4);
+    if (image.ops[0]) {
+      expect(image.ops[0].type).toBe('CREATE_RELATION');
+    }
+    if (image.ops[1]) {
+      expect(image.ops[1].type).toBe('SET_TRIPLE');
+    }
+    if (image.ops[2]) {
+      expect(image.ops[2].type).toBe('SET_TRIPLE');
+      if (image.ops[2].type === 'SET_TRIPLE') {
+        expect(image.ops[2].triple.attribute).toBe(SystemIds.IMAGE_HEIGHT_PROPERTY);
+      }
+    }
+    if (image.ops[3]) {
+      expect(image.ops[3].type).toBe('SET_TRIPLE');
+      if (image.ops[3].type === 'SET_TRIPLE') {
+        expect(image.ops[3].triple.attribute).toBe(SystemIds.IMAGE_WIDTH_PROPERTY);
+      }
+    }
+  });
+
+  it('creates an image from a blob', async () => {
+    const image = await createImage({
+      blob: testImageBlob,
+    });
+
+    expect(image).toBeDefined();
+    expect(typeof image.id).toBe('string');
+    expect(image.ops).toBeDefined();
+    expect(image.ops).toHaveLength(4);
+    if (image.ops[0]) {
+      expect(image.ops[0].type).toBe('CREATE_RELATION');
+    }
+    if (image.ops[1]) {
+      expect(image.ops[1].type).toBe('SET_TRIPLE');
+    }
+    if (image.ops[2]) {
+      expect(image.ops[2].type).toBe('SET_TRIPLE');
+      if (image.ops[2].type === 'SET_TRIPLE') {
+        expect(image.ops[2].triple.attribute).toBe(SystemIds.IMAGE_HEIGHT_PROPERTY);
+      }
+    }
+    if (image.ops[3]) {
+      expect(image.ops[3].type).toBe('SET_TRIPLE');
+      if (image.ops[3].type === 'SET_TRIPLE') {
+        expect(image.ops[3].triple.attribute).toBe(SystemIds.IMAGE_WIDTH_PROPERTY);
+      }
+    }
+  });
+
+  it('creates an image with a name and description', async () => {
+    const image = await createImage({
+      url: 'http://localhost:3000/image',
+      name: 'test image',
+      description: 'test description',
+    });
+
+    expect(image).toBeDefined();
+    expect(typeof image.id).toBe('string');
+    expect(image.ops).toBeDefined();
+    expect(image.ops).toHaveLength(6);
+    if (image.ops[4]) {
+      expect(image.ops[4].type).toBe('SET_TRIPLE');
+      if (image.ops[4].type === 'SET_TRIPLE') {
+        expect(image.ops[4].triple.value.value).toBe('test image');
+      }
+    }
+    if (image.ops[5]) {
+      expect(image.ops[5].type).toBe('SET_TRIPLE');
+      if (image.ops[5].type === 'SET_TRIPLE') {
+        expect(image.ops[5].triple.value.value).toBe('test description');
+      }
+    }
+  });
+
+  it('creates and image without dimensions in case they cannot be determined', async () => {
+    const testImageBlob = new Blob([new Uint8Array([0, 0, 0, 0])], { type: 'image/png' });
+    const image = await createImage({ blob: testImageBlob });
+    expect(image).toBeDefined();
+    expect(image.ops).toBeDefined();
+    expect(image.ops).toHaveLength(2);
+    if (image.ops[0]) {
+      expect(image.ops[0].type).toBe('CREATE_RELATION');
+    }
+    if (image.ops[1]) {
+      expect(image.ops[1].type).toBe('SET_TRIPLE');
+    }
+  });
+
+  it('throws an error if the image cannot be uploaded to IPFS', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(url => {
+      if (url.toString() === 'http://localhost:3000/image') {
+        return Promise.resolve({
+          status: 200,
+          blob: () => Promise.resolve(testImageBlob),
+        } as Response);
+      }
+      if (url.toString() === ipfsUploadUrl) {
+        return Promise.reject(new Error('Failed to upload image to IPFS'));
+      }
+      return vi.fn() as never;
+    });
+
+    await expect(
+      createImage({
+        url: 'http://localhost:3000/image',
+      }),
+    ).rejects.toThrow('Failed to upload image to IPFS');
+  });
+});

--- a/src/graph/create-image.ts
+++ b/src/graph/create-image.ts
@@ -1,0 +1,51 @@
+import { Image } from '../image.js';
+import { uploadImage } from '../ipfs.js';
+import type { CreateResult, Op } from '../types.js';
+import { createDefaultProperties } from './helpers/create-default-properties.js';
+type CreateImageParams =
+  | {
+      blob: Blob;
+      name?: string;
+      description?: string;
+    }
+  | {
+      url: string;
+      name?: string;
+      description?: string;
+    };
+
+/**
+ * Creates an entity with the given name, description, cover, properties, and types.
+ * All IDs passed to this function (cover, types, property IDs, relation IDs, etc.) are validated.
+ * If any invalid ID is provided, the function will throw an error.
+ *
+ * @example
+ * ```ts
+ * const { id, ops } = createImage({
+ *   url: 'https://example.com/image.png',
+ *   name: 'name of the image', // optional
+ *   description: 'description of the image', // optional
+ * });
+ *
+ * const { id, ops } = createImage({
+ *   blob: new Blob(…),
+ *   name: 'name of the image', // optional
+ *   description: 'description of the image', // optional
+ * });
+ * ```
+ * @param params – {@link CreateImageParams}
+ * @returns – {@link CreateResult}
+ * @throws Will throw an IpfsUploadError if the image cannot be uploaded to IPFS
+ */
+export const createImage = async ({ name, description, ...params }: CreateImageParams): Promise<CreateResult> => {
+  const ops: Array<Op> = [];
+  const { cid, dimensions } = await uploadImage(params);
+  const { id, ops: imageOps } = Image.make({ cid, dimensions });
+  ops.push(...imageOps);
+  ops.push(...createDefaultProperties({ entityId: id, name, description }));
+
+  return {
+    id,
+    ops,
+  };
+};

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,4 +1,5 @@
 export * from './create-entity.js';
+export * from './create-image.js';
 export * from './create-property.js';
 export * from './create-space.js';
 export * from './create-type.js';

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -6,6 +6,7 @@
  */
 
 import { Micro } from 'effect';
+import { imageSize } from 'image-size';
 
 import { EditProposal } from '../proto.js';
 import type { Op } from './types.js';
@@ -65,6 +66,69 @@ export async function publishEdit(args: PublishEditProposalArgs): Promise<string
     });
 
     return maybeCid as `ipfs://${string}`;
+  });
+
+  return await Micro.runPromise(upload);
+}
+
+type PublishImageParams =
+  | {
+      blob: Blob;
+    }
+  | {
+      url: string;
+    };
+
+export async function uploadImage(params: PublishImageParams) {
+  const formData = new FormData();
+  let blob: Blob;
+  if ('blob' in params) {
+    blob = params.blob;
+  } else {
+    // fetch the image and upload it to IPFS
+    const response = await fetch(params.url);
+    blob = await response.blob();
+  }
+
+  formData.append('file', blob);
+
+  const buffer = Buffer.from(await blob.arrayBuffer());
+  let dimensions: { width: number; height: number } | undefined;
+  try {
+    dimensions = imageSize(buffer);
+  } catch (error) {}
+
+  const upload = Micro.gen(function* () {
+    const result = yield* Micro.tryPromise({
+      try: () =>
+        fetch('https://api-testnet.grc-20.thegraph.com/ipfs/upload-file', {
+          method: 'POST',
+          body: formData,
+        }),
+      catch: error => new IpfsUploadError(`Could not upload edit to IPFS: ${error}`),
+    });
+
+    const maybeCid = yield* Micro.tryPromise({
+      try: async () => {
+        const { cid } = await result.json();
+        return cid;
+      },
+      catch: error => new IpfsUploadError(`Could not parse response from IPFS: ${error}`),
+    });
+
+    if (dimensions) {
+      return {
+        cid: maybeCid as `ipfs://${string}`,
+        dimensions: {
+          width: dimensions.width,
+          height: dimensions.height,
+        },
+      };
+    }
+
+    return {
+      cid: maybeCid as `ipfs://${string}`,
+    };
   });
 
   return await Micro.runPromise(upload);


### PR DESCRIPTION
## Introduces `createImage`

```ts
const { id: imageId, ops: createImageOps } = await Graph.createImage({
  url: 'https://example.com/image.png',
});

const { id: imageId, ops: createImageOps } = await Graph.createImage({
  blob: new Blob([fs.readFileSync(path.join(__dirname, 'cover.png'))], { type: 'image/png' });
});
```

Also name and description optionally can be passed in:

```ts
const { id: imageId, ops: createImageOps } = await Graph.createImage({
  url: 'https://example.com/image.png',
  name: "Name of the image",
  description: "Description of the image"
});
```

Image dimension are read out automatically if possible.