### PR TITLE
chore: rename args to params

### DIFF
--- a/.changeset/lemon-eyes-mix.md
+++ b/.changeset/lemon-eyes-mix.md
@@ -1,0 +1,5 @@
+---
+"@graphprotocol/grc-20": minor
+---
+
+rename types from "args" to "params" e.g. CreateTripleArgs to CreateTripleParams

--- a/src/core/blocks/data.ts
+++ b/src/core/blocks/data.ts
@@ -23,7 +23,7 @@ function getSourceTypeId(sourceType: DataBlockSourceType) {
   }
 }
 
-type DataBlockArgs = {
+type DataBlockParams = {
   fromId: string;
   sourceType: DataBlockSourceType;
   position?: string;
@@ -44,10 +44,10 @@ type DataBlockArgs = {
  * });
  * ```
  *
- * @param param args {@link TextBlockArgs}
+ * @param param args {@link TextBlockParams}
  * @returns ops – The ops for the Data Block entity: {@link Op}[]
  */
-export function make({ fromId, sourceType, position, name }: DataBlockArgs): (SetTripleOp | CreateRelationOp)[] {
+export function make({ fromId, sourceType, position, name }: DataBlockParams): (SetTripleOp | CreateRelationOp)[] {
   const newBlockId = generate();
 
   const dataBlockType = Relation.make({

--- a/src/core/blocks/text.ts
+++ b/src/core/blocks/text.ts
@@ -10,7 +10,7 @@ import { Relation } from '../../relation.js';
 import { SystemIds } from '../../system-ids.js';
 import type { Op } from '../../types.js';
 
-type TextBlockArgs = { fromId: string; text: string; position?: string };
+type TextBlockParams = { fromId: string; text: string; position?: string };
 
 /**
  * Returns the ops to create an entity representing a Text Block.
@@ -25,10 +25,10 @@ type TextBlockArgs = { fromId: string; text: string; position?: string };
  * });
  * ```
  *
- * @param param args {@link TextBlockArgs}
+ * @param param args {@link TextBlockParams}
  * @returns ops – The ops for the Text Block entity: {@link Op}[]
  */
-export function make({ fromId, text, position }: TextBlockArgs): Op[] {
+export function make({ fromId, text, position }: TextBlockParams): Op[] {
   const newBlockId = generate();
 
   const textBlockType = Relation.make({

--- a/src/core/relation.ts
+++ b/src/core/relation.ts
@@ -19,7 +19,7 @@ import { Position } from './position.js';
  * @param relationTypeId - base58 encoded v4 uuid
  * @param position - optional fractional index using position-strings
  */
-type CreateRelationArgs = {
+type CreateRelationParams = {
   relationId?: string;
   fromId: string;
   toId: string;
@@ -42,10 +42,10 @@ type CreateRelationArgs = {
  * });
  * ```
  *
- * @param args {@link CreateRelationArgs}
+ * @param args {@link CreateRelationParams}
  * @returns – {@link CreateRelationOp}
  */
-export function make(args: CreateRelationArgs): CreateRelationOp {
+export function make(args: CreateRelationParams): CreateRelationOp {
   const newEntityId = args.relationId ?? generate();
 
   return {
@@ -80,7 +80,7 @@ export function remove(relationId: string): DeleteRelationOp {
   };
 }
 
-type ReorderRelationArgs = {
+type ReorderRelationParams = {
   relationId: string;
   beforeIndex?: string;
   afterIndex?: string;
@@ -110,10 +110,10 @@ type ReorderRelationOp = {
  * });
  * ```
  *
- * @param args {@link ReorderRelationArgs}
+ * @param args {@link ReorderRelationParams}
  * @returns – {@link ReorderRelationOp}
  */
-export function reorder(args: ReorderRelationArgs): ReorderRelationOp {
+export function reorder(args: ReorderRelationParams): ReorderRelationOp {
   const newIndex = Position.createBetween(args.beforeIndex, args.afterIndex);
 
   return {

--- a/src/core/triple.ts
+++ b/src/core/triple.ts
@@ -6,7 +6,7 @@
 
 import type { DeleteTripleOp, SetTripleOp, Value } from '../types.js';
 
-type CreateTripleArgs = {
+type CreateTripleParams = {
   attributeId: string;
   entityId: string;
   value: Value;
@@ -26,10 +26,10 @@ type CreateTripleArgs = {
  *   },
  * });
  * ```
- * @param args – {@link CreateTripleArgs}
+ * @param args – {@link CreateTripleParams}
  * @returns – {@link SetTripleOp}
  */
-export function make(args: CreateTripleArgs): SetTripleOp {
+export function make(args: CreateTripleParams): SetTripleOp {
   return {
     type: 'SET_TRIPLE',
     triple: {
@@ -40,7 +40,7 @@ export function make(args: CreateTripleArgs): SetTripleOp {
   };
 }
 
-type DeleteTripleArgs = {
+type DeleteTripleParams = {
   attributeId: string;
   entityId: string;
 };
@@ -56,10 +56,10 @@ type DeleteTripleArgs = {
  * });
  * ```
  *
- * @param args – {@link DeleteTripleArgs}
+ * @param args – {@link DeleteTripleParams}
  * @returns – {@link DeleteTripleOp}
  */
-export function remove(args: DeleteTripleArgs): DeleteTripleOp {
+export function remove(args: DeleteTripleParams): DeleteTripleOp {
   return {
     type: 'DELETE_TRIPLE',
     triple: {

--- a/src/encodings/get-calldata-for-space-governance-type.ts
+++ b/src/encodings/get-calldata-for-space-governance-type.ts
@@ -2,13 +2,13 @@ import { encodeFunctionData, stringToHex } from 'viem';
 
 import { MainVotingAbi, PersonalSpaceAdminAbi } from '../abis/index.js';
 
-type GovernanceTypeCalldataArgs = {
+type GovernanceTypeCalldataParams = {
   type: 'PUBLIC' | 'PERSONAL';
   cid: string;
   spacePluginAddress: string;
 };
 
-export function getCalldataForSpaceGovernanceType(args: GovernanceTypeCalldataArgs) {
+export function getCalldataForSpaceGovernanceType(args: GovernanceTypeCalldataParams) {
   switch (args.type) {
     case 'PUBLIC':
       return encodeFunctionData({

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -14,7 +14,7 @@ class IpfsUploadError extends Error {
   readonly _tag = 'IpfsUploadError';
 }
 
-type PublishEditProposalArgs = {
+type PublishEditProposalParams = {
   name: string;
   ops: Op[];
   author: string;
@@ -34,10 +34,10 @@ type PublishEditProposalArgs = {
  * });
  * ```
  *
- * @param args arguments for publishing an edit to IPFS {@link PublishEditProposalArgs}
+ * @param args arguments for publishing an edit to IPFS {@link PublishEditProposalParams}
  * @returns IPFS CID representing the edit prefixed with `ipfs://`
  */
-export async function publishEdit(args: PublishEditProposalArgs): Promise<string> {
+export async function publishEdit(args: PublishEditProposalParams): Promise<string> {
   const { name, ops, author } = args;
 
   const edit = EditProposal.encode({ name, ops, author });

--- a/src/proto/edit.ts
+++ b/src/proto/edit.ts
@@ -2,13 +2,13 @@ import { generate } from '../id.js';
 import type { Op } from '../types.js';
 import { ActionType, Edit, Entity, Op as OpBinary, OpType, Relation, Triple } from './gen/src/proto/ipfs_pb.js';
 
-type MakeEditProposalArgs = {
+type MakeEditProposalParams = {
   name: string;
   ops: Op[];
   author: string;
 };
 
-export function encode({ name, ops, author }: MakeEditProposalArgs): Uint8Array {
+export function encode({ name, ops, author }: MakeEditProposalParams): Uint8Array {
   return new Edit({
     type: ActionType.ADD_EDIT,
     version: '1.0.0',


### PR DESCRIPTION
We want to consistently use one term to avoid confusing API users.

## Background why we choose `params`

In JavaScript, **"args" (arguments)** and **"params" (parameters)** are often used interchangeably, but they have distinct meanings in the context of functions.

### 1. **Parameters (`params`)**
- **Definition:** Parameters are the named variables listed in a function definition.  
- **Scope:** They act as placeholders and are defined when a function is declared.  
- **Example:**
  ```js
  function greet(name, age) {  // "name" and "age" are parameters
    console.log(`Hello, my name is ${name} and I am ${age} years old.`);
  }
  ```

### 2. **Arguments (`args`)**
- **Definition:** Arguments are the actual values passed to a function when it is called.  
- **Scope:** These values are assigned to the corresponding parameters in the function.  
- **Example:**
  ```js
  greet("Alice", 25);  // "Alice" and 25 are arguments
  ```

### 3. **Which One to Use?**
- **Use parameters** when defining a function to specify what values the function expects.
- **Use arguments** when calling a function to provide the actual values.