### PR TITLE
release: simpler CSV metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @graphprotocol/grc-20
 
+## 0.9.4
+
+### Patch Changes
+
+- Simplify CSV column metadata fields
+
 ## 0.9.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/grc-20",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "license": "MIT",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/core/ids/system.ts
+++ b/src/core/ids/system.ts
@@ -1,5 +1,7 @@
 import { Id } from '../../id.js';
 
+export const ENTITY_ID_PROPERTY = Id('4E7MAYWAn14fuY853CHVLs')
+
 export const PROPERTY = Id('GscJ2GELQjmLoaVrYyR3xm');
 /**
  * @deprecated use PROPERTY

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,8 +32,6 @@ export type CsvMetadata = {
   columns: {
     id: string;
     type: ValueType | 'RELATION';
-    relationType?: string;
-    isId?: boolean;
     options?: TripleValueOptions;
   }[];
 };


### PR DESCRIPTION
We no longer need to support the `isId` or `relationType` metadata fields.