### PR TITLE
feat: optional params for createSpace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @graphprotocol/grc-20
 
+## 0.20.0
+
+### Minor Changes
+
+- Introduce optional spaceEntityId and ops when creating space
+
 ## 0.19.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/grc-20",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "MIT",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/graph/create-space.ts
+++ b/src/graph/create-space.ts
@@ -1,33 +1,45 @@
-import type { Op } from '../../proto.js';
-import { MAINNET_API_ORIGIN, TESTNET_API_ORIGIN } from './constants.js';
+import type {Op} from "../types.js"
+import {MAINNET_API_ORIGIN, TESTNET_API_ORIGIN} from "./constants.js"
 
 type Params = {
-  editorAddress: string;
-  name: string;
-  network?: 'TESTNET' | 'MAINNET';
-  ops?: Op[],
-  spaceEntityId?: string;
-};
+	editorAddress: string
+	name: string
+	network?: "TESTNET" | "MAINNET"
+	ops?: Op[]
+	spaceEntityId?: string
+}
 
 /**
  * Creates a space with the given name and editor address.
  */
 export const createSpace = async (params: Params) => {
-  const apiHost = params.network === 'TESTNET' ? TESTNET_API_ORIGIN : MAINNET_API_ORIGIN;
-  console.log('apiHost', apiHost);
-  const result = await fetch(`${apiHost}/deploy`, {
-    method: 'POST',
-    body: JSON.stringify({
-      spaceName: params.name,
-      initialEditorAddress: params.editorAddress,
-      ops: params.ops,
-      spaceEntity: params.spaceEntityId
-    }),
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
+	const apiHost = params.network === "TESTNET" ? TESTNET_API_ORIGIN : MAINNET_API_ORIGIN
+	console.log("apiHost", apiHost)
 
-  const jsonResult = await result.json();
-  return { id: jsonResult.spaceId };
-};
+	const formData = new FormData()
+	formData.append("name", params.name)
+	formData.append("editorAddress", params.editorAddress)
+	if (params.spaceEntityId) {
+		formData.append("spaceEntityId", params.spaceEntityId)
+	}
+
+	if (params.ops) {
+		formData.append("ops", JSON.stringify(params.ops))
+	}
+
+	const result = await fetch(`${apiHost}/deploy`, {
+		method: "POST",
+		body: JSON.stringify({
+			spaceName: params.name,
+			initialEditorAddress: params.editorAddress,
+			ops: params.ops,
+			spaceEntityId: params.spaceEntityId,
+		}),
+		headers: {
+			"Content-Type": "application/json",
+		},
+	})
+
+	const jsonResult = await result.json()
+	return {id: jsonResult.spaceId}
+}

--- a/src/graph/create-space.ts
+++ b/src/graph/create-space.ts
@@ -1,9 +1,12 @@
+import type { Op } from '../../proto.js';
 import { MAINNET_API_ORIGIN, TESTNET_API_ORIGIN } from './constants.js';
 
 type Params = {
   editorAddress: string;
   name: string;
   network?: 'TESTNET' | 'MAINNET';
+  ops?: Op[],
+  spaceEntityId?: string;
 };
 
 /**
@@ -17,6 +20,8 @@ export const createSpace = async (params: Params) => {
     body: JSON.stringify({
       spaceName: params.name,
       initialEditorAddress: params.editorAddress,
+      ops: params.ops,
+      spaceEntity: params.spaceEntityId
     }),
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
This PR adds support for users passing additional ops when creating a space. Often a user will want to seed new spaces with data beyond just the space's name and type.

For example, maybe I want to add additional types, or create a set of entities during space creation. 

Users can now also provide a `spaceEntityId` which will be used by the API as the canonical "Space Entity."

```ts
const newEntity = Graph.createEntity({
   values: [
	{
	    property: NAME_PROPERTY,
	    value: "Test Entity",
	},
   ],
   types: [PROJECT_TYPE],
})

const space = await Graph.createSpace({
    name: "test (nik)",
    ops: newEntity.ops,
    spaceEntityId: newEntity.id
})

```