### PR TITLE
feat: public space deploys

### DIFF
--- a/.changeset/pretty-crabs-move.md
+++ b/.changeset/pretty-crabs-move.md
@@ -1,0 +1,5 @@
+---
+"@graphprotocol/grc-20": minor
+---
+
+Added new configuration to Graph.createSpace to support deploying public spaces.

--- a/src/graph/create-space.ts
+++ b/src/graph/create-space.ts
@@ -1,45 +1,88 @@
-import type {Op} from "../types.js"
-import {MAINNET_API_ORIGIN, TESTNET_API_ORIGIN} from "./constants.js"
+import type { Op } from '../types.js';
+import { MAINNET_API_ORIGIN, TESTNET_API_ORIGIN } from './constants.js';
 
 type Params = {
-	editorAddress: string
-	name: string
-	network?: "TESTNET" | "MAINNET"
-	ops?: Op[]
-	spaceEntityId?: string
-}
+  editorAddress: string;
+  name: string;
+  network?: 'TESTNET' | 'MAINNET';
+  ops?: Op[];
+  spaceEntityId?: string;
+
+  /**
+   * Select which contracts to deploy based on the governance type.
+   * If no governance type is provided it defaults to PERSONAL
+   */
+  governanceType?: 'PUBLIC' | 'PERSONAL';
+};
+
+type BaseDeployParams = {
+  spaceName: string;
+  ops?: Op[];
+  spaceEntityId?: string;
+};
+
+type DeployParams = BaseDeployParams &
+  (
+    | {
+        initialEditorAddresses: string[];
+      }
+    | {
+        initialEditorAddress: string;
+      }
+  );
 
 /**
  * Creates a space with the given name and editor address.
  */
 export const createSpace = async (params: Params) => {
-	const apiHost = params.network === "TESTNET" ? TESTNET_API_ORIGIN : MAINNET_API_ORIGIN
-	console.log("apiHost", apiHost)
+  const governanceType = params.governanceType ?? 'PERSONAL';
+  const apiHost = params.network === 'TESTNET' ? TESTNET_API_ORIGIN : MAINNET_API_ORIGIN;
+  console.log('apiHost', apiHost);
 
-	const formData = new FormData()
-	formData.append("name", params.name)
-	formData.append("editorAddress", params.editorAddress)
-	if (params.spaceEntityId) {
-		formData.append("spaceEntityId", params.spaceEntityId)
-	}
+  const formData = new FormData();
+  formData.append('name', params.name);
+  formData.append('editorAddress', params.editorAddress);
+  if (params.spaceEntityId) {
+    formData.append('spaceEntityId', params.spaceEntityId);
+  }
 
-	if (params.ops) {
-		formData.append("ops", JSON.stringify(params.ops))
-	}
+  if (params.ops) {
+    formData.append('ops', JSON.stringify(params.ops));
+  }
 
-	const result = await fetch(`${apiHost}/deploy`, {
-		method: "POST",
-		body: JSON.stringify({
-			spaceName: params.name,
-			initialEditorAddress: params.editorAddress,
-			ops: params.ops,
-			spaceEntityId: params.spaceEntityId,
-		}),
-		headers: {
-			"Content-Type": "application/json",
-		},
-	})
+  let url = `${apiHost}/deploy`;
 
-	const jsonResult = await result.json()
-	return {id: jsonResult.spaceId}
-}
+  const deployParams: DeployParams =
+    governanceType === 'PERSONAL'
+      ? {
+          spaceName: params.name,
+          ops: params.ops,
+          spaceEntityId: params.spaceEntityId,
+          initialEditorAddress: params.editorAddress,
+        }
+      : {
+          spaceName: params.name,
+          ops: params.ops,
+          spaceEntityId: params.spaceEntityId,
+          initialEditorAddresses: [params.editorAddress],
+        };
+
+  if (governanceType === 'PERSONAL') {
+    url = `${url}/personal`;
+  }
+
+  if (governanceType === 'PUBLIC') {
+    url = `${url}/public`;
+  }
+
+  const result = await fetch(url, {
+    method: 'POST',
+    body: JSON.stringify(deployParams),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const jsonResult = await result.json();
+  return { id: jsonResult.spaceId };
+};


### PR DESCRIPTION
This PR adds support for deploying public spaces. I've added a new flag to `createSpace` where callers specify the governance mode they want for their space. By default if no mode is provided it defaults to `PERSONAL`.

I tested using the full flow test for both modes and without a mode specified.